### PR TITLE
Add merges to CheckAndProcessElderChange

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -7,9 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::utilities::{
-    Attributes, Candidate, ChangeElder, GenesisPfxInfo, LocalEvent, Name, Node, NodeChange,
-    NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo, Rpc, Section,
-    SectionInfo, State,
+    Attributes, Candidate, ChangeElder, GenesisPfxInfo, LocalEvent, MergeInfo, Name, Node,
+    NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo, Rpc,
+    Section, SectionInfo, State,
 };
 use itertools::Itertools;
 use std::{
@@ -33,6 +33,9 @@ pub struct InnerAction {
 
     pub shortest_prefix: Option<Section>,
     pub section_members: BTreeMap<SectionInfo, Vec<Node>>,
+
+    pub merge_infos: Option<MergeInfo>,
+    pub merge_needed: bool,
 }
 
 impl InnerAction {
@@ -49,6 +52,9 @@ impl InnerAction {
 
             shortest_prefix: Default::default(),
             section_members: Default::default(),
+
+            merge_infos: Default::default(),
+            merge_needed: false,
         }
     }
 
@@ -116,6 +122,10 @@ impl InnerAction {
 
     fn set_section_info(&mut self, section: SectionInfo) {
         self.our_section = section;
+    }
+
+    fn store_merge_infos(&mut self, merge_info: MergeInfo) {
+        self.merge_infos = Some(merge_info);
     }
 }
 
@@ -376,6 +386,22 @@ impl Action {
     }
 
     pub fn increment_nodes_work_units(&self) {}
+
+    pub fn store_merge_infos(&self, merge_info: MergeInfo) {
+        self.0.borrow_mut().store_merge_infos(merge_info);
+    }
+
+    pub fn has_merge_infos(&self) -> bool {
+        self.0.borrow().merge_infos.is_some()
+    }
+
+    pub fn merge_needed(&self) -> bool {
+        self.0.borrow().merge_needed
+    }
+
+    pub fn set_merge_needed(&self, merge_needed: bool) {
+        self.0.borrow_mut().merge_needed = merge_needed;
+    }
 }
 
 impl Default for Action {

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -8,7 +8,9 @@
 
 use crate::{
     state::{AcceptAsCandidateState, MemberState, ProcessElderChangeState},
-    utilities::{Candidate, ChangeElder, Event, LocalEvent, Node, ParsecVote, Proof, Rpc, Section},
+    utilities::{
+        Candidate, ChangeElder, Event, LocalEvent, MergeInfo, Node, ParsecVote, Proof, Rpc, Section,
+    },
 };
 use unwrap::unwrap;
 
@@ -282,7 +284,8 @@ impl CheckAndProcessElderChange {
 
     fn try_consensus(&self, vote: &ParsecVote) -> Option<Self> {
         match vote {
-            ParsecVote::CheckElder => Some(self.check_elder()),
+            ParsecVote::NeighbourMerge(merge_info) => Some(self.store_merge_infos(*merge_info)),
+            ParsecVote::CheckElder => Some(self.check_merge()),
             _ => None,
         }
     }
@@ -291,6 +294,29 @@ impl CheckAndProcessElderChange {
         match rpc {
             Rpc::Merge => Some(self.vote_parsec_neighbour_merge()),
             _ => None,
+        }
+    }
+
+    fn store_merge_infos(&self, merge_info: MergeInfo) -> Self {
+        self.0.action.store_merge_infos(merge_info);
+        self.clone()
+    }
+
+    fn merge_needed(&self) -> bool {
+        self.0.action.merge_needed()
+    }
+
+    fn has_merge_infos(&self) -> bool {
+        self.0.action.has_merge_infos()
+    }
+
+    fn check_merge(&self) -> Self {
+        if self.has_merge_infos() || self.merge_needed() {
+            // TODO: -> Concurrent to ProcessMerge
+            self.0.action.send_rpc(Rpc::Merge);
+            self.clone()
+        } else {
+            self.check_elder()
         }
     }
 
@@ -319,7 +345,9 @@ impl CheckAndProcessElderChange {
     }
 
     fn vote_parsec_neighbour_merge(&self) -> Self {
-        self.0.action.vote_parsec(ParsecVote::NeighbourMerge);
+        self.0
+            .action
+            .vote_parsec(ParsecVote::NeighbourMerge(MergeInfo));
         self.clone()
     }
 

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -271,6 +271,7 @@ impl CheckAndProcessElderChange {
     pub fn try_next(&self, event: Event) -> Option<MemberState> {
         match event {
             Event::ParsecConsensus(vote) => self.try_consensus(&vote),
+            Event::Rpc(rpc) => self.try_rpc(rpc),
             Event::LocalEvent(LocalEvent::TimeoutCheckElder) => {
                 Some(self.vote_parsec_check_elder())
             }
@@ -282,6 +283,13 @@ impl CheckAndProcessElderChange {
     fn try_consensus(&self, vote: &ParsecVote) -> Option<Self> {
         match vote {
             ParsecVote::CheckElder => Some(self.check_elder()),
+            _ => None,
+        }
+    }
+
+    fn try_rpc(&self, rpc: Rpc) -> Option<Self> {
+        match rpc {
+            Rpc::Merge => Some(self.vote_parsec_neighbour_merge()),
             _ => None,
         }
     }
@@ -307,6 +315,11 @@ impl CheckAndProcessElderChange {
 
     fn vote_parsec_check_elder(&self) -> Self {
         self.0.action.vote_parsec(ParsecVote::CheckElder);
+        self.clone()
+    }
+
+    fn vote_parsec_neighbour_merge(&self) -> Self {
+        self.0.action.vote_parsec(ParsecVote::NeighbourMerge);
         self.clone()
     }
 

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -577,6 +577,19 @@ mod dst_tests {
     }
 
     #[test]
+    fn rpc_merge() {
+        run_test(
+            "Get RPC Merge",
+            &initial_state_old_elders(),
+            &[Rpc::Merge.to_event()],
+            &AssertState {
+                action_our_votes: vec![ParsecVote::NeighbourMerge],
+                ..AssertState::default()
+            },
+        );
+    }
+
+    #[test]
     fn parsec_expect_candidate_then_online_no_elder_change() {
         let initial_state = arrange_initial_state(
             &initial_state_old_elders(),

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 use lazy_static::lazy_static;
+use pretty_assertions::assert_eq;
 
 macro_rules! to_collect {
     ($($item:expr),*) => {{
@@ -1332,6 +1333,7 @@ mod src_tests {
 mod node_tests {
     use super::*;
     use crate::state::JoiningRelocateCandidateState;
+    use pretty_assertions::assert_eq;
 
     #[derive(Debug, PartialEq, Default, Clone)]
     struct AssertJoiningState {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -202,6 +202,8 @@ pub enum Rpc {
         destination: Name,
         connection_info: i32,
     },
+
+    Merge,
 }
 
 impl Rpc {
@@ -216,7 +218,8 @@ impl Rpc {
             | Rpc::RelocatedInfo(_, _)
             | Rpc::ExpectCandidate(_)
             | Rpc::ResendExpectCandidate(_, _)
-            | Rpc::NodeApproval(_, _) => None,
+            | Rpc::NodeApproval(_, _)
+            | Rpc::Merge => None,
 
             Rpc::ResourceProof { candidate, .. } | Rpc::ResourceProofReceipt { candidate, .. } => {
                 Some(Name(candidate.0.name))
@@ -249,6 +252,8 @@ pub enum ParsecVote {
 
     Offline(Node),
     BackOnline(Node),
+
+    NeighbourMerge,
 }
 
 impl ParsecVote {
@@ -272,7 +277,8 @@ impl ParsecVote {
             | ParsecVote::RelocatedInfo(_)
             | ParsecVote::CheckElder
             | ParsecVote::Offline(_)
-            | ParsecVote::BackOnline(_) => None,
+            | ParsecVote::BackOnline(_)
+            | ParsecVote::NeighbourMerge => None,
         }
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -104,6 +104,9 @@ pub struct SectionInfo(pub Section, pub i32 /*contain full membership */);
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Ord, Eq)]
 pub struct GenesisPfxInfo(pub SectionInfo);
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Ord, Eq)]
+pub struct MergeInfo;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChangeElder {
     pub changes: Vec<(Node, bool)>,
@@ -253,7 +256,7 @@ pub enum ParsecVote {
     Offline(Node),
     BackOnline(Node),
 
-    NeighbourMerge,
+    NeighbourMerge(MergeInfo),
 }
 
 impl ParsecVote {
@@ -278,7 +281,7 @@ impl ParsecVote {
             | ParsecVote::CheckElder
             | ParsecVote::Offline(_)
             | ParsecVote::BackOnline(_)
-            | ParsecVote::NeighbourMerge => None,
+            | ParsecVote::NeighbourMerge(_) => None,
         }
     }
 }


### PR DESCRIPTION
Add merges to CheckAndProcessElderChange flow tests

Render of graphs used: 
~https://raw.githack.com/maidsafe/routing/bd2d7d32cb1fcffc57e652df3fa5ff0f92f430fe/routing_model/index.html~
https://raw.githack.com/maidsafe/routing_model/3fce6d4e0ebce93ba027126476e9158e3f0393e9/routing_model/index.html

The sub-process ProcessMerge is missing and would be the next logical step