### PR TITLE
Destination flow up to date

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
       ParsecConsensus((Consensus))
 
       ParsecConsensus -- "Parsec::CheckRelocatedNodeConnection" --> CleanCandidates
-      CleanCandidates["for candidate in both<br/>-waiting_node_connecting()<br/>-CANDIDATES:<br/><br/>purge_node_info(candidate)<br/><br/>CANDIDATES_INFO<br/>.retain(|(k,v)|is_valid_waited_info(v))<br/>CANDIDATES_VOTED<br/>.retain(|src| CANDIDATES_INFO.contains_key(src))<br/>CANDIDATES=waiting_node_connecting()<br/><br/>(reject candidates that took too long)"]
+      CleanCandidates["for candidate in both<br/>-waiting_nodes_connecting()<br/>-CANDIDATES:<br/><br/>purge_node_info(candidate)<br/><br/>CANDIDATES_INFO<br/>.retain(|(k,v)|is_valid_waited_info(v))<br/>CANDIDATES_VOTED<br/>.retain(|src| CANDIDATES_INFO.contains_key(src))<br/>CANDIDATES=waiting_nodes_connecting()<br/><br/>(reject candidates that took too long)"]
       CleanCandidates --> ReStartCheckRelocatedNodeConnectionTimeout
       ReStartCheckRelocatedNodeConnectionTimeout["schedule(<br/>CheckRelocatedNodeConnectionTimeout)"]
       ReStartCheckRelocatedNodeConnectionTimeout --> LoopEnd
@@ -709,7 +709,7 @@
     Using a target address instead of a section ensures we deliver the message even if the destination splits or merges.<br/>
     <br/>
     There are 3 states the node may be: State::RelocatingAgeIncrease, State::RelocatingHop, and State::RelocatingBackOnline.<br/>
-    Nodes will be selected in this order: State::RelocatingAgeIncrease, State::RelocatingHop and then State::RelocatingBackOnline.<br/>
+    Nodes will be selected in this order: State::RelocatingAgeIncrease, State::RelocatingHop and then State::RelocatingBackOnline and tie break by age then name.<br/>
     This ensures that we prioritise good node relocation.
     <br/>
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occurred.

--- a/index.html
+++ b/index.html
@@ -261,11 +261,16 @@
     Note that we could also see consensus on Parsec::ExpectCandidate before we ourselves voted for it in PARSEC, as long as enough members of our section did.
     </p>
   </div>
-  <button class="collapsible">waiting_proofing_or_hop</button>
+  <button class="collapsible">count_waiting_proofing_or_hop</button>
   <div class="content">
     <p>We want to accept at most one incoming relocation at a time into our section.<br/>
-    The waiting_proofing_or_hop function returns the list of nodes that we have yet to resource proof or relocate through a new hop, (States from State::WaitingCandidateInfo until it reaches State::Online  or State::Relocated).<br/>
-    When the output of this function is not empty and we reach consensus on Parsec::ExpectCandidate, we send a Rpc::ExpectCandidateRefuseResponse to the would-be-incoming-node so they can try another section or try again later.
+    The count_waiting_proofing_or_hop function returns the count of nodes that we have yet to resource proof or relocate through a new hop, (States from State::WaitingCandidateInfo until it reaches State::Online  or State::Relocated).<br/>
+    When the output of this function is not 0 and we reach consensus on Parsec::ExpectCandidate, we send a Rpc::ExpectCandidateRefuseResponse to the would-be-incoming-node so they can try another section or try again later.
+    </p>
+  </div>
+  <button class="collapsible">get_waiting_candidate_info</button>
+  <div class="content">
+    <p>If we already accepted a candidate, reply with the same info we provided intially and returned by get_waiting_candidate_info.
     </p>
   </div>
   </div>
@@ -294,11 +299,11 @@
       VoteParsecExpectCandidate --> LoopEnd
 
       Balanced(("Check"))
-      Balanced -- "waiting_proofing_or_hop()<br/>.contains(candidate)" --> SendIdenticalExpectCandidateAcceptResponse
-      Balanced -- "waiting_proofing_or_hop()<br/>.is_empty()" --> SendExpectCandidateAcceptResponse
+      Balanced -- "get_waiting_candidate_info(candidate).is_some()" --> SendIdenticalExpectCandidateAcceptResponse
+      Balanced -- "count_waiting_proofing_or_hop()==0" --> SendExpectCandidateAcceptResponse
       Balanced -- "Otherwise" --> SendRefuse
 
-      SendIdenticalExpectCandidateAcceptResponse["send_rpc(<br/>Rpc::ExpectCandidateAcceptResponse)<br/>again to source section<br/>with original info"]
+      SendIdenticalExpectCandidateAcceptResponse["send_rpc(<br/>Rpc::ExpectCandidateAcceptResponse)<br/>again to source section<br/>with original info<br/>get_waiting_candidate_info(candidate)"]
       SendIdenticalExpectCandidateAcceptResponse --> LoopEnd
 
       SendExpectCandidateAcceptResponse["add_node(<br/>NodeState=State::WaitingCandidateInfo)<br/><br/>send_rpc(<br/>Rpc::ExpectCandidateAcceptResponse)<br/>to source section"]
@@ -312,12 +317,16 @@
 
   <h2>Relocated node connection</h2>
   <div class=description>
-  <p>Manage node with NodeState=State::WaitingConnectionInfo and connection info request/response RPCs.<br/>
+  <p>Manage node with NodeState=State::WaitingCandidateInfo and connection info request/response RPCs.<br/>
     The candidate sends its CandidateInfo to the NaeManager of the target interval to ensure it reaches the section even in the event of a split or a merge.<br/>
     This target interval address could be the middle address of the interval, and the interval should cover a range that will not be split if the section splits.<br/>
     When we complete, we either stop responding to Rpc::CandidateInfo RPCs if it failed, or we send Rpc::NodeConnected on success,<br/>
     (We could also omit Rpc::NodeConnected, the node would continue sending CandidateInfo until Rpc::ResourceProof or time out).<br/>
-    When the node reaches State::WaitingProofing or State::RelocatingHop state, the section becomes responsible for managing communication with this node as it would any of its adults.
+    When the node reaches State::WaitingProofing or State::RelocatingHop state, the section becomes responsible for managing communication with this node as it would any of its adults.<br/>
+    <br/>
+    Re-insert Parsec::CandidateConnected in case of prefix change (i.e split/merge + checkpoint), and CANDIDATES_INFO/CANDIDATES_VOTED should be kept.
+    Do not re-insert votes for which is_valid_waited_info is false (discarded candidates will never reach consensus).
+    (Alternatively could always discard votes on prefix change and clear CANDIDATES_INFO/CANDIDATES_VOTED)
   </p>
   <button class="collapsible">is_valid_waited_info</button>
   <div class="content">
@@ -329,11 +338,6 @@
         </ul>
     </p>
   </div>
-  <button class="collapsible">is_valid_waited_connection</button>
-  <div class="content">
-    <p>Return true if the given message_src of the current RPC is a one of our nodes and is in State::WaitingConnectionInfo state.
-    </p>
-  </div>
   <button class="collapsible">shorter_prefix_section</button>
   <div class="content">
     <p>If we know of a section that has a shorter prefix than ours, we prefer for them to receive this incoming node rather than ourselves as it will help keep the Network's sections tree balanced.<br/>
@@ -341,10 +345,33 @@
     If it is Some, we will relocate the new node to them instead of completing the relocation to our own section.
     </p>
   </div>
+  <button class="collapsible">update_to_node</button>
+  <div class="content">
+    <p>Convert the candidate node at the target interval address to a node using the new_public_id from the given CandidateInfo.
+       Update the state of the node with the given state.
+    </p>
+  </div>
   <button class="collapsible">State::RelocatingHop</button>
   <div class="content">
     <p>A nodes state indicating that it is relocated without ageing further.<br/>
-       Also returned as part of waiting_proofing_or_hop().
+       Also counted as part of count_waiting_proofing_or_hop().
+    </p>
+  </div>
+  <button class="collapsible">CANDIDATES</button>
+  <div class="content">
+    <p>Collection of candidate that we will purge if they are still in State::WaitingCandidateInfo next time Parsec::CheckRelocatedNodeConnection is consensused.
+    </p>
+  </div>
+  <button class="collapsible">CANDIDATES_INFO</button>
+  <div class="content">
+    <p>Collection of CandidateInfo keyed by CandidateInfo.new_public_id.<br/>
+    For all items, only keep if is_valid_waited_info(info)==true.
+    </p>
+  </div>
+  <button class="collapsible">CANDIDATES_VOTED</button>
+  <div class="content">
+    <p>Collection of candidates CandidateInfo.new_public_id that we have voted for as connected<br/>
+    For all items, only keep if also kept in CANDIDATES_INFO.
     </p>
   </div>
   <button class="collapsible">RelocatedNodeConnection_Reset</button>
@@ -371,28 +398,28 @@
       ParsecConsensus((Consensus))
 
       ParsecConsensus -- "Parsec::CheckRelocatedNodeConnection" --> CleanCandidates
-      CleanCandidates["for candidate in both<br/>-waiting_node_connecting()<br/>-CANDIDATES:<br/><br/>purge_node_info(candidate)"]
+      CleanCandidates["for candidate in both<br/>-waiting_node_connecting()<br/>-CANDIDATES:<br/><br/>purge_node_info(candidate)<br/><br/>CANDIDATES_INFO<br/>.retain(|(k,v)|is_valid_waited_info(v))<br/>CANDIDATES_VOTED<br/>.retain(|src| CANDIDATES_INFO.contains_key(src))<br/>CANDIDATES=waiting_node_connecting()<br/><br/>(reject candidates that took too long)"]
       CleanCandidates --> ReStartCheckRelocatedNodeConnectionTimeout
-      ReStartCheckRelocatedNodeConnectionTimeout["CANDIDATES=waiting_node_connecting()<br/><br/>schedule(<br/>CheckRelocatedNodeConnectionTimeout)"]
+      ReStartCheckRelocatedNodeConnectionTimeout["schedule(<br/>CheckRelocatedNodeConnectionTimeout)"]
       ReStartCheckRelocatedNodeConnectionTimeout --> LoopEnd
 
+      ParsecConsensus -- "Parsec::CandidateConnected" --> CheckValidConnected
+      CheckValidConnected((Check))
+      CheckValidConnected -- "is_valid_waited_info(<br/>Parsec::CandidateConnected info)" --> Balanced
 
-      ParsecConsensus -- "Parsec::CandidateInfo<br/>and<br/>is_valid_waited_info(<br/>CandidateInfo,<br/>message_src)" --> SetCandidateInfo
-      SetCandidateInfo["update_node(<br/>CandidateInfo,<br/>NodeState=State::WaitingConnectionInfo)"]
-      SetCandidateInfo --> LoopEnd
-
-      ParsecConsensus -- "Parsec::CandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> Balanced
       Balanced(("Check"))
       Balanced -- "shorter_prefix_section(<br/>).is_some()" --> RelocateToShorterPrefix
-      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>State::RelocatingHop)"]
+      RelocateToShorterPrefix["update_to_node(<br/>Parsec::CandidateConnected info,<br/>State::RelocatingHop)"]
       RelocateToShorterPrefix --> SetConnected
 
       Balanced -- "Otherwise" --> SetWaitingProof
-      SetWaitingProof["set_node_state(<br/>candidate,<br/>State::WaitingProofing)"]
+      SetWaitingProof["update_to_node(<br/>Parsec::CandidateConnected info,<br/>State::WaitingProofing)"]
       SetWaitingProof --> SetConnected
 
       SetConnected["send_rpc(<br/>Rpc::NodeConnected)<br/><br/>(All communications now<br/>managed by elder like<br/>for other adults)"]
       SetConnected --> LoopEnd
+
+      CheckValidConnected -- "Otherwise" --> LoopEnd
 
       RPC((RPC))
       WaitFor --"RPC"--> RPC
@@ -403,16 +430,12 @@
       DiscardRPC[Discard RPC]
       DiscardRPC --> LoopEnd
 
-      CheckCandidateInfo -- "is_valid_waited_info(<br/>CandidateInfo)" --> VoteForCandidateInfo
-      VoteForCandidateInfo["vote_for(<br/>Parsec::CandidateInfo)"]
-      VoteForCandidateInfo --> LoopEnd
-
-      CheckCandidateInfo -- "is_valid_waited_connection(<br/>message_src)" --> SendConnectionInfoRequest
-      SendConnectionInfoRequest["send_rpc(<br/>Rpc::ConnectionInfoRequest)"]
+      CheckCandidateInfo -- "is_valid_waited_info(<br/>CandidateInfo)" --> SendConnectionInfoRequest
+      SendConnectionInfoRequest["CANDIDATES_INFO<br/>.insert_if_not_exists(<br/>CandidateInfo.new_public_id,<br/>CandidateInfo info)<br/><br/>send_rpc(<br/>Rpc::ConnectionInfoRequest)<br/><br/>(cache candidate info and<br/>send connect info)"]
       SendConnectionInfoRequest --> LoopEnd
 
-      RPC -- "Rpc::ConnectionInfoResponse<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> ConnectCandidate
-      ConnectCandidate["connect_to_candidate(<br/>ConnectionInfoResponse info)<br/><br/>vote_for(<br/>Parsec::CandidateConnected)"]
+      RPC -- "Rpc::ConnectionInfoResponse<br/>and<br/>CANDIDATES_INFO<br/>.contains_key(message_src)<br/>and<br/>!CANDIDATES_VOTED<br/>.contains(message_src)" --> ConnectCandidate
+      ConnectCandidate["connect_to_candidate(<br/>ConnectionInfoResponse info)<br/><br/>vote_for(<br/>Parsec::CandidateConnected{<br/>CANDIDATES_INFO.get(message_src)})<br/><br/>CANDIDATES_VOTED.insert(message_src)<br/><br/>(connect and vote for<br/>candidate connected)"]
       ConnectCandidate --> LoopEnd
 
       WaitFor --Event--> Event

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -7,9 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::utilities::{
-    Age, Attributes, Candidate, CandidateInfo, ChangeElder, GenesisPfxInfo, MergeInfo, LocalEvent, Name, Node,
-    NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo, Rpc,
-    Section, SectionInfo, State,
+    Age, Attributes, Candidate, CandidateInfo, ChangeElder, GenesisPfxInfo, LocalEvent, MergeInfo,
+    Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo,
+    Rpc, Section, SectionInfo, State,
 };
 use itertools::Itertools;
 use std::{
@@ -199,9 +199,9 @@ impl Action {
         self.0.borrow_mut().next_target_interval.0 += 1;
 
         let info = RelocatedInfo {
-            candidate: candidate,
+            candidate,
             expected_age: Age(candidate.0.age + 1),
-            target_interval_center: target_interval_center,
+            target_interval_center,
             section_info: self.0.borrow().our_section,
         };
 
@@ -229,7 +229,7 @@ impl Action {
     fn update_to_node(&self, info: CandidateInfo, state: State) {
         let state = NodeState {
             node: Node(info.new_public_id.0),
-            state: state,
+            state,
             ..NodeState::default()
         };
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -195,19 +195,19 @@ impl Action {
     }
 
     pub fn add_node_waiting_candidate_info(&self, candidate: Candidate) -> RelocatedInfo {
-        let target_interval_center = self.0.borrow().next_target_interval;
+        let target_interval_centre = self.0.borrow().next_target_interval;
         self.0.borrow_mut().next_target_interval.0 += 1;
 
         let info = RelocatedInfo {
             candidate,
             expected_age: Age(candidate.0.age + 1),
-            target_interval_center,
+            target_interval_centre,
             section_info: self.0.borrow().our_section,
         };
 
         let state = NodeState {
             node: Node(Attributes {
-                name: info.target_interval_center.0,
+                name: info.target_interval_centre.0,
                 age: info.expected_age.0,
             }),
             state: State::WaitingCandidateInfo(info),
@@ -373,6 +373,7 @@ impl Action {
                     state.state == State::RelocatingHop,
                     state.state == State::RelocatingBackOnline,
                     state.node.0.age(),
+                    state.node.0.name(),
                 )
             })
             .map(|state| (Candidate(state.node.0), Section::default()))
@@ -387,7 +388,7 @@ impl Action {
             .unwrap_or(false)
     }
 
-    pub fn waiting_node_connecting(&self) -> BTreeSet<Name> {
+    pub fn waiting_nodes_connecting(&self) -> BTreeSet<Name> {
         self.0
             .borrow()
             .our_current_nodes

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -353,19 +353,6 @@ impl Action {
             .unwrap_or(false)
     }
 
-    pub fn is_valid_waited_connection(&self, info: CandidateInfo) -> bool {
-        if !info.valid {
-            return false;
-        }
-
-        self.0
-            .borrow()
-            .our_current_nodes
-            .get(&Name(info.candidate.0.name))
-            .map(|state| state.state.is_waiting_connection_info())
-            .unwrap_or(false)
-    }
-
     pub fn is_our_name(&self, name: Name) -> bool {
         self.our_name() == name
     }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -314,6 +314,26 @@ impl Action {
             .unwrap_or(false)
     }
 
+    pub fn waiting_proofing_or_hop(&self) -> Vec<Node> {
+        self.0
+            .borrow()
+            .our_current_nodes
+            .values()
+            .filter(|state| state.state.is_resource_proofing())
+            .map(|state| state.node)
+            .collect()
+    }
+
+    pub fn resource_proof_candidate(&self) -> Option<Candidate> {
+        self.0
+            .borrow()
+            .our_current_nodes
+            .values()
+            .filter(|state| state.state.is_resource_proofing())
+            .map(|state| Candidate(state.node.0))
+            .next()
+    }
+
     pub fn is_our_name(&self, name: Name) -> bool {
         self.our_name() == name
     }

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -12,8 +12,8 @@ use crate::{
         StartRelocatedNodeConnectionState,
     },
     utilities::{
-        Candidate, CandidateInfo, ChangeElder, Event, LocalEvent, Name, MergeInfo, Node, ParsecVote, Proof,
-        RelocatedInfo, Rpc,
+        Candidate, CandidateInfo, ChangeElder, Event, LocalEvent, MergeInfo, Name, Node,
+        ParsecVote, Proof, RelocatedInfo, Rpc,
     },
 };
 use unwrap::unwrap;
@@ -155,18 +155,19 @@ impl StartRelocatedNodeConnection {
     }
 
     fn rpc_info(&self, info: CandidateInfo) -> Self {
-        match self.0.action.is_valid_waited_info(info) {
-            true => self.cache_candidate_info_and_send_connect_info(info),
-            false => self.discard(),
+        if self.0.action.is_valid_waited_info(info) {
+            self.cache_candidate_info_and_send_connect_info(info)
+        } else {
+            self.discard()
         }
     }
 
     fn check_candidate_connnected(&self, info: CandidateInfo) -> Self {
-        match self.0.action.is_valid_waited_info(info) {
-            false => self.discard(),
-            true => self
-                .check_update_to_node(info)
-                .send_node_connected_rpc(info),
+        if self.0.action.is_valid_waited_info(info) {
+            self.check_update_to_node(info)
+                .send_node_connected_rpc(info)
+        } else {
+            self.discard()
         }
     }
 
@@ -402,9 +403,10 @@ impl StartResourceProof {
     }
 
     fn check_request_resource_proof(&self) -> Self {
-        match self.has_candidate() {
-            true => self.send_resource_proof_rpc(),
-            false => self.finish_resource_proof(),
+        if self.has_candidate() {
+            self.send_resource_proof_rpc()
+        } else {
+            self.finish_resource_proof()
         }
     }
 

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     state::{
-        AcceptAsCandidateState, MemberState, ProcessElderChangeState,
-        StartRelocatedNodeConnectionState,
+        MemberState, ProcessElderChangeState, StartRelocatedNodeConnectionState,
+        StartResourceProofState,
     },
     utilities::{
         Candidate, CandidateInfo, ChangeElder, Event, LocalEvent, MergeInfo, Name, Node,
@@ -19,9 +19,9 @@ use crate::{
 use unwrap::unwrap;
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct TopLevelDst(pub MemberState);
+pub struct RespondToRelocateRequests(pub MemberState);
 
-impl TopLevelDst {
+impl RespondToRelocateRequests {
     pub fn try_next(&self, event: Event) -> Option<MemberState> {
         match event {
             Event::Rpc(rpc) => self.try_rpc(rpc),
@@ -324,12 +324,12 @@ impl StartResourceProof {
         }
     }
 
-    fn routine_state(&self) -> &AcceptAsCandidateState {
-        &self.0.sub_routine_accept_as_candidate
+    fn routine_state(&self) -> &StartResourceProofState {
+        &self.0.start_resource_proof
     }
 
-    fn mut_routine_state(&mut self) -> &mut AcceptAsCandidateState {
-        &mut self.0.sub_routine_accept_as_candidate
+    fn mut_routine_state(&mut self) -> &mut StartResourceProofState {
+        &mut self.0.start_resource_proof
     }
 
     fn discard(&self) -> Self {

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -115,7 +115,7 @@ impl StartRelocatedNodeConnection {
 
     fn try_consensus(&self, vote: ParsecVote) -> Option<Self> {
         match vote {
-            ParsecVote::CandidateConnected(info) => Some(self.check_candidate_connnected(info)),
+            ParsecVote::CandidateConnected(info) => Some(self.check_candidate_connected(info)),
             ParsecVote::CheckRelocatedNodeConnection => Some(
                 self.reject_candidates_that_took_too_long()
                     .schedule_time_out(),
@@ -162,7 +162,7 @@ impl StartRelocatedNodeConnection {
         }
     }
 
-    fn check_candidate_connnected(&self, info: CandidateInfo) -> Self {
+    fn check_candidate_connected(&self, info: CandidateInfo) -> Self {
         if self.0.action.is_valid_waited_info(info) {
             self.check_update_to_node(info)
                 .send_node_connected_rpc(info)
@@ -194,17 +194,17 @@ impl StartRelocatedNodeConnection {
     fn reject_candidates_that_took_too_long(&self) -> Self {
         let mut state = self.clone();
 
-        let new_connecting_nodes = state.0.action.waiting_node_connecting();
-        let node_to_remove: Vec<Name> = new_connecting_nodes
+        let new_connecting_nodes = state.0.action.waiting_nodes_connecting();
+        let nodes_to_remove: Vec<Name> = new_connecting_nodes
             .intersection(&state.routine_state().candidates)
             .cloned()
             .collect();
 
-        for name in node_to_remove {
+        for name in nodes_to_remove {
             state.0.action.purge_node_info(name);
         }
 
-        let candidates = state.0.action.waiting_node_connecting();
+        let candidates = state.0.action.waiting_nodes_connecting();
         let mut_routine_state = &mut state.mut_routine_state();
 
         mut_routine_state.candidates = candidates.clone();

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -93,10 +93,10 @@ impl TopLevelDst {
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct AcceptAsCandidate(pub MemberState);
+pub struct StartResourceProof(pub MemberState);
 
 // AcceptAsCandidate Sub Routine
-impl AcceptAsCandidate {
+impl StartResourceProof {
     // TODO - remove the `allow` once we have a test for this method.
     #[allow(dead_code)]
     fn start_event_loop(&self) -> Self {

--- a/src/flows_src.rs
+++ b/src/flows_src.rs
@@ -138,7 +138,7 @@ impl StartRelocateSrc {
             }
             ParsecVote::RelocatedInfo(info) => Some(
                 self.send_candidate_relocated_info_rpc(info)
-                    .purge_node_info(info.candidate),
+                    .purge_node_info(info),
             ),
             // Delegate to other event loops
             _ => None,
@@ -225,8 +225,8 @@ impl StartRelocateSrc {
         self.clone()
     }
 
-    fn purge_node_info(&self, candidate: Candidate) -> Self {
-        self.0.action.remove_node(candidate);
+    fn purge_node_info(&self, info: RelocatedInfo) -> Self {
+        self.0.action.purge_node_info(info.candidate.name());
         self.clone()
     }
 

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -10,9 +10,9 @@ use crate::{
     actions::*,
     state::*,
     utilities::{
-        Age, Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent, MergeInfo, Name,
-        Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo,
-        Rpc, Section, SectionInfo, State,
+        Age, Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent,
+        MergeInfo, Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource,
+        RelocatedInfo, Rpc, Section, SectionInfo, State,
     },
 };
 use lazy_static::lazy_static;

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -43,9 +43,10 @@ const CANDIDATE_205: Candidate = Candidate(Attributes { name: 205, age: 5 });
 const OTHER_SECTION_1: Section = Section(1);
 const DST_SECTION_200: Section = Section(200);
 
+const NODE_1_OLD: Node = Node(ATTRIBUTES_1_OLD);
 const NODE_1: Node = Node(ATTRIBUTES_1);
-const NODE_2: Node = Node(ATTRIBUTES_2);
 const NODE_2_OLD: Node = Node(ATTRIBUTES_2_OLD);
+const NODE_2: Node = Node(ATTRIBUTES_2);
 const SET_ONLINE_NODE_1: NodeChange = NodeChange::State(Node(ATTRIBUTES_1), State::Online);
 const REMOVE_NODE_1: NodeChange = NodeChange::Remove(Name(ATTRIBUTES_1.name));
 
@@ -75,7 +76,7 @@ const CANDIDATE_INFO_VALID_1: CandidateInfo = CandidateInfo {
 const CANDIDATE_RELOCATED_INFO_1: RelocatedInfo = RelocatedInfo {
     candidate: CANDIDATE_1_OLD,
     expected_age: Age(CANDIDATE_1_OLD.0.age + 1),
-    target_interval_center: TARGET_INTERVAL_1,
+    target_interval_centre: TARGET_INTERVAL_1,
     section_info: OUR_INITIAL_SECTION_INFO,
 };
 
@@ -233,7 +234,7 @@ fn get_relocated_info(candidate: Candidate, section_info: SectionInfo) -> Reloca
     RelocatedInfo {
         candidate,
         expected_age: Age(candidate.0.age + 1),
-        target_interval_center: TARGET_INTERVAL_1,
+        target_interval_centre: TARGET_INTERVAL_1,
         section_info,
     }
 }
@@ -965,8 +966,9 @@ mod dst_tests {
             ],
         );
 
-        let description = "Get Parsec ExpectCandidate then Online (Elder Change) RemoveElderNode for wrong elder,\
-            AddElderNode for wrong node, NewSectionInfo for wrong section";
+        let description =
+            "Get Parsec ExpectCandidate then Online (Elder Change) RemoveElderNode \
+             for wrong elder, AddElderNode for wrong node, NewSectionInfo for wrong section";
         run_test(
             description,
             &initial_state,
@@ -1094,7 +1096,7 @@ mod dst_tests {
                     State::WaitingCandidateInfo(RelocatedInfo {
                         candidate: CANDIDATE_2_OLD,
                         expected_age: CANDIDATE_2.0.age(),
-                        target_interval_center: TARGET_INTERVAL_2,
+                        target_interval_centre: TARGET_INTERVAL_2,
                         section_info: OUR_NEXT_SECTION_INFO,
                     }),
                 )],
@@ -1102,7 +1104,7 @@ mod dst_tests {
                 action_our_rpcs: vec![Rpc::RelocateResponse(RelocatedInfo {
                     candidate: CANDIDATE_2_OLD,
                     expected_age: CANDIDATE_2.0.age(),
-                    target_interval_center: TARGET_INTERVAL_2,
+                    target_interval_centre: TARGET_INTERVAL_2,
                     section_info: OUR_NEXT_SECTION_INFO,
                 })],
                 ..AssertState::default()
@@ -1385,21 +1387,24 @@ mod src_tests {
                             state: State::RelocatingHop,
                             ..NodeState::default()
                         },
-                        &[NODE_1],
+                        &[NODE_1_OLD],
                     )
                     .extend_current_nodes_with(
                         &NodeState {
                             state: State::RelocatingBackOnline,
                             ..NodeState::default()
                         },
-                        &[NODE_2, NODE_2_OLD],
+                        &[NODE_2, NODE_2_OLD, NODE_1],
                     ),
             ),
             ..MemberState::default()
         };
 
+        let description = "RelocatingHop or RelocatingBackOnline does not stop relocating our \
+        adults. Also relocated nodes are relocated AgeIncrease, then Hop, then BackOnline, break \
+        tie by age then name";
         run_test(
-            "RelocatingHop does not stop relocating our adults. Also relocated second",
+            description,
             &initial_state,
             &[
                 ParsecVote::WorkUnitIncrement.to_event(),
@@ -1411,7 +1416,7 @@ mod src_tests {
             &AssertState {
                 action_our_rpcs: vec![
                     Rpc::ExpectCandidate(CANDIDATE_205),
-                    Rpc::ExpectCandidate(CANDIDATE_1),
+                    Rpc::ExpectCandidate(CANDIDATE_1_OLD),
                     Rpc::ExpectCandidate(CANDIDATE_2),
                     Rpc::ExpectCandidate(CANDIDATE_205),
                 ],

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -10,8 +10,8 @@ use crate::{
     actions::*,
     state::*,
     utilities::{
-        Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent, MergeInfo, Name, Node,
-        NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo, Rpc,
+        Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent, MergeInfo, Name,
+        Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo, Rpc,
         Section, SectionInfo, State,
     },
 };
@@ -265,29 +265,11 @@ mod dst_tests {
             &initial_state,
             &[CANDIDATE_INFO_VALID_RPC_1.to_event()],
             &AssertState {
-                action_our_votes: vec![CANDIDATE_INFO_VALID_PARSEC_VOTE_1],
-                ..AssertState::default()
-            },
-        );
-    }
-
-    #[test]
-    fn parsec_expect_candidate_then_parsec_candidate_info() {
-        let initial_state = arrange_initial_state(
-            &initial_state_old_elders(),
-            &[
-                ParsecVote::ExpectCandidate(CANDIDATE_1).to_event(),
-                ParsecVote::CheckResourceProof.to_event(),
-            ],
-        );
-
-        run_test(
-            "Get Parsec ExpectCandidate then Purge",
-            &initial_state,
-            &[CANDIDATE_INFO_VALID_PARSEC_VOTE_1.to_event()],
-            &AssertState {
-                action_our_nodes: vec![NodeChange::State(NODE_1, State::WaitingProofing)],
-                //action_our_votes: vec![CANDIDATE_INFO_VALID_PARSEC_VOTE_1],
+                action_our_rpcs: vec![Rpc::ConnectionInfoRequest {
+                    source: OUR_NAME,
+                    destination: CANDIDATE_1.name(),
+                    connection_info: OUR_NAME.0,
+                }],
                 ..AssertState::default()
             },
         );
@@ -314,11 +296,7 @@ mod dst_tests {
                     source: OUR_NAME,
                     proof: OUR_PROOF_REQUEST,
                 }],
-                action_our_votes: vec![ParsecVote::CandidateInfo(CandidateInfo {
-                    candidate: CANDIDATE_1,
-                    destination: Name(132),
-                    valid: true,
-                })],
+                action_our_votes: vec![CANDIDATE_INFO_VALID_PARSEC_VOTE_1],
                 ..AssertState::default()
             },
         );
@@ -339,8 +317,29 @@ mod dst_tests {
             &initial_state,
             &[CANDIDATE_INFO_VALID_RPC_1.to_event()],
             &AssertState {
-                // Not right but diagram allow it.
-                action_our_votes: vec![CANDIDATE_INFO_VALID_PARSEC_VOTE_1],
+                action_our_rpcs: vec![Rpc::ConnectionInfoRequest {
+                    source: OUR_NAME,
+                    destination: CANDIDATE_1.name(),
+                    connection_info: OUR_NAME.0,
+                }],
+                ..AssertState::default()
+            },
+        );
+    }
+
+    #[test]
+    fn parsec_expect_candidate_then_parsec_candidate_info() {
+        let initial_state = arrange_initial_state(
+            &initial_state_old_elders(),
+            &[ParsecVote::ExpectCandidate(CANDIDATE_1).to_event()],
+        );
+
+        run_test(
+            "Get Parsec ExpectCandidate then Purge",
+            &initial_state,
+            &[CANDIDATE_INFO_VALID_PARSEC_VOTE_1.to_event()],
+            &AssertState {
+                action_our_nodes: vec![NodeChange::State(NODE_1, State::WaitingProofing)],
                 ..AssertState::default()
             },
         );

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -148,7 +148,6 @@ struct AssertState {
     action_our_events: Vec<LocalEvent>,
     action_our_section: SectionInfo,
     action_merge_infos: Option<MergeInfo>,
-    sub_routine_accept_as_candidate: AcceptAsCandidateState,
     check_and_process_elder_change_routine: CheckAndProcessElderChangeState,
 }
 
@@ -184,7 +183,6 @@ fn run_test(
             action_our_events: action.our_events,
             action_our_section: action.our_section,
             action_merge_infos: action.merge_infos,
-            sub_routine_accept_as_candidate: final_state.sub_routine_accept_as_candidate,
             check_and_process_elder_change_routine: final_state
                 .check_and_process_elder_change_routine,
         },
@@ -247,11 +245,6 @@ mod dst_tests {
             &AssertState {
                 action_our_nodes: vec![ADD_PROOFING_NODE_1],
                 action_our_rpcs: vec![Rpc::RelocateResponse(CANDIDATE_1, OUR_INITIAL_SECTION_INFO)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -277,11 +270,6 @@ mod dst_tests {
                     source: OUR_NAME,
                     proof: OUR_PROOF_REQUEST,
                 }],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -302,14 +290,7 @@ mod dst_tests {
             "Get Parsec ExpectCandidate then Purge",
             &initial_state,
             &[CANDIDATE_INFO_VALID_RPC_1.to_event()],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: false,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -334,11 +315,6 @@ mod dst_tests {
             .to_event()],
             &AssertState {
                 action_our_votes: vec![ParsecVote::PurgeCandidate(CANDIDATE_1)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -360,11 +336,6 @@ mod dst_tests {
             &[LocalEvent::TimeoutAccept.to_event()],
             &AssertState {
                 action_our_votes: vec![ParsecVote::PurgeCandidate(CANDIDATE_1)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -389,14 +360,7 @@ mod dst_tests {
                 valid: true,
             }
             .to_event()],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -425,11 +389,6 @@ mod dst_tests {
                     candidate: CANDIDATE_1,
                     source: OUR_NAME,
                 }],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -457,11 +416,6 @@ mod dst_tests {
             .to_event()],
             &AssertState {
                 action_our_votes: vec![ParsecVote::Online(CANDIDATE_1)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: true,
-                },
                 ..AssertState::default()
             },
         );
@@ -493,14 +447,7 @@ mod dst_tests {
                 proof: Proof::ValidEnd,
             }
             .to_event()],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: true,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -524,14 +471,7 @@ mod dst_tests {
                 proof: Proof::Invalid,
             }
             .to_event()],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: false,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -555,14 +495,7 @@ mod dst_tests {
                 proof: Proof::ValidEnd,
             }
             .to_event()],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: true,
-                    voted_online: false,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -583,14 +516,7 @@ mod dst_tests {
                 ParsecVote::Online(CANDIDATE_2).to_event(),
                 ParsecVote::PurgeCandidate(CANDIDATE_2).to_event(),
             ],
-            &AssertState {
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -807,7 +733,7 @@ mod dst_tests {
                 ParsecVote::AddElderNode(NODE_1).to_event(),
                 ParsecVote::NewSectionInfo(SECTION_INFO_1).to_event(),
             ],
-            & AssertState{
+            &AssertState {
                 action_our_section: SECTION_INFO_1,
                 action_our_nodes: vec![
                     NodeChange::Elder(NODE_1, true),
@@ -846,11 +772,6 @@ mod dst_tests {
                 action_our_section: SECTION_INFO_1,
                 action_our_nodes: vec![ADD_PROOFING_NODE_2],
                 action_our_rpcs: vec![Rpc::RelocateResponse(CANDIDATE_2, OUR_NEXT_SECTION_INFO)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_2),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );
@@ -893,11 +814,6 @@ mod dst_tests {
             &[ParsecVote::ExpectCandidate(CANDIDATE_2).to_event()],
             &AssertState {
                 action_our_rpcs: vec![Rpc::RefuseCandidate(CANDIDATE_2)],
-                sub_routine_accept_as_candidate: AcceptAsCandidateState {
-                    candidate: Some(CANDIDATE_1),
-                    got_candidate_info: false,
-                    voted_online: false,
-                },
                 ..AssertState::default()
             },
         );

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,7 +22,7 @@ pub struct CheckAndProcessElderChangeState {
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct AcceptAsCandidateState {
+pub struct StartResourceProofState {
     pub candidate: Option<Candidate>,
     pub got_candidate_info: bool,
     pub voted_online: bool,
@@ -48,10 +48,10 @@ pub struct SrcRoutineState {}
 pub struct MemberState {
     pub action: Action,
     pub failure: Option<Event>,
-    pub sub_routine_accept_as_candidate: AcceptAsCandidateState,
+    pub start_resource_proof: StartResourceProofState,
+    pub start_relocated_node_connection_state: StartRelocatedNodeConnectionState,
     pub src_routine: SrcRoutineState,
     pub start_relocate_src: StartRelocateSrcState,
-    pub start_relocated_node_connection_state: StartRelocatedNodeConnectionState,
     pub check_and_process_elder_change_routine: CheckAndProcessElderChangeState,
 }
 
@@ -91,7 +91,7 @@ impl MemberState {
             return Some(next);
         }
 
-        if let Some(next) = self.as_top_level_dst().try_next(event) {
+        if let Some(next) = self.as_respond_to_relocate_requests().try_next(event) {
             return Some(next);
         }
 
@@ -116,8 +116,8 @@ impl MemberState {
         }
     }
 
-    pub fn as_top_level_dst(&self) -> TopLevelDst {
-        TopLevelDst(self.clone())
+    pub fn as_respond_to_relocate_requests(&self) -> RespondToRelocateRequests {
+        RespondToRelocateRequests(self.clone())
     }
 
     pub fn as_start_relocated_node_connection(&self) -> StartRelocatedNodeConnection {

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,7 +35,8 @@ pub struct StartRelocateSrcState {
 
 // #[derive(Debug, PartialEq, Default, Clone)]
 // pub struct StartRelocatedNodeConnectionState {
-//     pub candidates_info: BTreeMap<Candidate, i32>,
+//     pub candidates_info: BTreeMap<Name, CandidateInfo>,
+//     pub candidates_voted: BTreeSet<Name>,
 // }
 
 #[derive(Debug, PartialEq, Default, Clone)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,6 +33,11 @@ pub struct StartRelocateSrcState {
     pub already_relocating: BTreeMap<Candidate, i32>,
 }
 
+// #[derive(Debug, PartialEq, Default, Clone)]
+// pub struct StartRelocatedNodeConnectionState {
+//     pub candidates_info: BTreeMap<Candidate, i32>,
+// }
+
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct SrcRoutineState {}
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,7 +75,7 @@ impl MemberState {
             return Some(next);
         }
 
-        if let Some(next) = self.as_accept_as_candidate().try_next(event) {
+        if let Some(next) = self.as_start_resource_proof().try_next(event) {
             return Some(next);
         }
 
@@ -99,8 +99,8 @@ impl MemberState {
         TopLevelDst(self.clone())
     }
 
-    pub fn as_accept_as_candidate(&self) -> AcceptAsCandidate {
-        AcceptAsCandidate(self.clone())
+    pub fn as_start_resource_proof(&self) -> StartResourceProof {
+        StartResourceProof(self.clone())
     }
 
     pub fn as_check_and_process_elder_change(&self) -> CheckAndProcessElderChange {

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,6 +75,10 @@ impl MemberState {
             return Some(next);
         }
 
+        if let Some(next) = self.as_start_relocated_node_connection().try_next(event) {
+            return Some(next);
+        }
+
         if let Some(next) = self.as_start_resource_proof().try_next(event) {
             return Some(next);
         }
@@ -97,6 +101,10 @@ impl MemberState {
 
     pub fn as_top_level_dst(&self) -> TopLevelDst {
         TopLevelDst(self.clone())
+    }
+
+    pub fn as_start_relocated_node_connection(&self) -> StartRelocatedNodeConnection {
+        StartRelocatedNodeConnection(self.clone())
     }
 
     pub fn as_start_resource_proof(&self) -> StartResourceProof {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -64,10 +64,8 @@ pub enum State {
     RelocatingAnyReason,
     // Complete relocation, only waiting for info to be processed
     Relocated(RelocatedInfo),
-    // Not a full adult/Not known pubilc id: still wait candidate info
+    // Not a full adult/Not known pubilc id: still wait candidate info / connection
     WaitingCandidateInfo,
-    // Not a full adult/still communicate using proxy: still wait for connection
-    WaitingConnectionInfo,
     // Not a full adult: still wait proofing
     WaitingProofing,
     // When a node that was previous online lost connection
@@ -86,15 +84,9 @@ impl State {
         self == State::WaitingCandidateInfo
     }
 
-    pub fn is_waiting_connection_info(self) -> bool {
-        self == State::WaitingConnectionInfo
-    }
-
     pub fn is_not_yet_full_node(self) -> bool {
         match self {
-            State::WaitingCandidateInfo | State::WaitingConnectionInfo | State::WaitingProofing => {
-                true
-            }
+            State::WaitingCandidateInfo | State::WaitingProofing => true,
             _ => false,
         }
     }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -60,7 +60,7 @@ pub enum NodeChange {
 pub struct RelocatedInfo {
     pub candidate: Candidate,
     pub expected_age: Age,
-    pub target_interval_center: Name,
+    pub target_interval_centre: Name,
     pub section_info: SectionInfo,
 }
 
@@ -77,13 +77,13 @@ pub enum State {
     Online,
     // Relocating an adult that has reached its work unit count
     RelocatingAgeIncrease,
-    // Relocating to a new hop with a shorter section
+    // Relocating to a new hop with a shorter section prefix
     RelocatingHop,
     // Relocating back online node
     RelocatingBackOnline,
     // Complete relocation, only waiting for info to be processed
     Relocated(RelocatedInfo),
-    // Not a full adult/Not known pubilc id: still wait candidate info / connection
+    // Not a full adult / Not known public id: still wait candidate info / connection
     WaitingCandidateInfo(RelocatedInfo),
     // Not a full adult: still wait proofing
     WaitingProofing,

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -74,6 +74,11 @@ impl State {
     pub fn is_relocating(self) -> bool {
         self == State::RelocatingAnyReason
     }
+
+    pub fn is_resource_proofing(self) -> bool {
+        self == State::WaitingProofing
+    }
+
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -239,8 +244,11 @@ impl Rpc {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ParsecVote {
     ExpectCandidate(Candidate),
+
     Online(Candidate),
     PurgeCandidate(Candidate),
+    CheckResourceProof,
+
     AddElderNode(Node),
     RemoveElderNode(Node),
     NewSectionInfo(SectionInfo),
@@ -272,7 +280,8 @@ impl ParsecVote {
             | ParsecVote::RefuseCandidate(candidate)
             | ParsecVote::RelocateResponse(candidate, _) => Some(*candidate),
 
-            ParsecVote::AddElderNode(_)
+            ParsecVote::CheckResourceProof
+            | ParsecVote::AddElderNode(_)
             | ParsecVote::RemoveElderNode(_)
             | ParsecVote::NewSectionInfo(_)
             | ParsecVote::WorkUnitIncrement
@@ -289,6 +298,7 @@ impl ParsecVote {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LocalEvent {
     TimeoutAccept,
+    CheckResourceProofTimeout,
 
     TimeoutWorkUnit,
     TimeoutCheckRelocate,


### PR DESCRIPTION
Fix diagrams to be correct and simpler to implement.
Mostly implement the diagram. Some name changes are still needed, but most of the functionality for the destination relocation flow is now in sync.

The different commits help clarify the different transformation required to move from the old model to the new and more complete model, however, it is likely simpler to review the combined work and only use the other commit as reference.

Rendered:
https://raw.githack.com/maidsafe/routing_model/dbe89e7a8b859dd5d9e998c1b9639e6250681c35/index.html