### PR TITLE
various clean up for tests 

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -9,7 +9,7 @@
 use crate::utilities::{
     Age, Attributes, Candidate, CandidateInfo, ChangeElder, GenesisPfxInfo, LocalEvent, MergeInfo,
     Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource, RelocatedInfo,
-    Rpc, Section, SectionInfo, State,
+    Rpc, Section, SectionInfo, State, TestEvent,
 };
 use itertools::Itertools;
 use std::{
@@ -99,11 +99,6 @@ impl InnerAction {
         self
     }
 
-    pub fn with_shortest_prefix(mut self, shortest_prefix: Option<Section>) -> Self {
-        self.shortest_prefix = shortest_prefix;
-        self
-    }
-
     fn add_node(&mut self, node_state: NodeState) {
         self.our_nodes
             .push(NodeChange::AddWithState(node_state.node, node_state.state));
@@ -180,6 +175,13 @@ impl Action {
         inner.our_rpc.clear();
         inner.our_nodes.clear();
         inner.our_events.clear();
+    }
+
+    pub fn process_test_events(&self, event: TestEvent) {
+        match event {
+            TestEvent::SetMergeNeeded(value) => self.0.borrow_mut().merge_needed = value,
+            TestEvent::SetShortestPrefix(value) => self.0.borrow_mut().shortest_prefix = value,
+        }
     }
 
     pub fn vote_parsec(&self, vote: ParsecVote) {
@@ -532,10 +534,6 @@ impl Action {
 
     pub fn merge_needed(&self) -> bool {
         self.0.borrow().merge_needed
-    }
-
-    pub fn set_merge_needed(&self, merge_needed: bool) {
-        self.0.borrow_mut().merge_needed = merge_needed;
     }
 }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -134,6 +134,8 @@ impl InnerAction {
 
     fn set_section_info(&mut self, section: SectionInfo) {
         self.our_section = section;
+        self.our_events
+            .push(ActionTriggered::OurSectionChanged(section).to_event());
     }
 
     fn store_merge_infos(&mut self, merge_info: MergeInfo) {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -7,9 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::utilities::{
-    Age, Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent,
-    MergeInfo, Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource,
-    RelocatedInfo, Rpc, Section, SectionInfo, State, TestEvent,
+    ActionTriggered, Age, Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo,
+    LocalEvent, MergeInfo, Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest,
+    ProofSource, RelocatedInfo, Rpc, Section, SectionInfo, State, TestEvent,
 };
 use itertools::Itertools;
 use std::{
@@ -186,6 +186,10 @@ impl Action {
     }
 
     pub fn schedule_event(&self, event: LocalEvent) {
+        self.0.borrow_mut().our_events.push(event.to_event());
+    }
+
+    pub fn action_triggered(&self, event: ActionTriggered) {
         self.0.borrow_mut().our_events.push(event.to_event());
     }
 
@@ -515,7 +519,9 @@ impl Action {
         });
     }
 
-    pub fn increment_nodes_work_units(&self) {}
+    pub fn increment_nodes_work_units(&self) {
+        self.action_triggered(ActionTriggered::WorkUnitIncremented);
+    }
 
     pub fn store_merge_infos(&self, merge_info: MergeInfo) {
         self.0.borrow_mut().store_merge_infos(merge_info);

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -138,6 +138,8 @@ impl InnerAction {
 
     fn store_merge_infos(&mut self, merge_info: MergeInfo) {
         self.merge_infos = Some(merge_info);
+        self.our_events
+            .push(ActionTriggered::MergeInfoStored(merge_info).to_event());
     }
 }
 

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -12,8 +12,8 @@ use crate::{
         StartResourceProofState,
     },
     utilities::{
-        Candidate, CandidateInfo, ChangeElder, Event, LocalEvent, MergeInfo, Name, Node,
-        ParsecVote, Proof, RelocatedInfo, Rpc,
+        Candidate, CandidateInfo, ChangeElder, LocalEvent, MergeInfo, Name, Node, ParsecVote,
+        Proof, RelocatedInfo, Rpc, WaitedEvent,
     },
 };
 use unwrap::unwrap;
@@ -22,10 +22,10 @@ use unwrap::unwrap;
 pub struct RespondToRelocateRequests(pub MemberState);
 
 impl RespondToRelocateRequests {
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::Rpc(rpc) => self.try_rpc(rpc),
-            Event::ParsecConsensus(vote) => self.try_consensus(vote),
+            WaitedEvent::Rpc(rpc) => self.try_rpc(rpc),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(vote),
             _ => None,
         }
         .map(|state| state.0)
@@ -94,11 +94,11 @@ impl StartRelocatedNodeConnection {
         self.schedule_time_out()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::Rpc(rpc) => self.try_rpc(rpc),
-            Event::ParsecConsensus(vote) => self.try_consensus(vote),
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::Rpc(rpc) => self.try_rpc(rpc),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(vote),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
         }
         .map(|state| state.0)
     }
@@ -272,13 +272,13 @@ impl StartResourceProof {
         self.clone()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::Rpc(Rpc::ResourceProofResponse {
+            WaitedEvent::Rpc(Rpc::ResourceProofResponse {
                 candidate, proof, ..
             }) => Some(self.rpc_proof(candidate, proof)),
-            Event::ParsecConsensus(vote) => self.try_consensus(vote),
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(vote),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
             // Delegate to other event loops
             _ => None,
         }
@@ -437,11 +437,11 @@ impl CheckAndProcessElderChange {
         self.start_check_elder_timeout()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::ParsecConsensus(vote) => self.try_consensus(&vote),
-            Event::Rpc(rpc) => self.try_rpc(rpc),
-            Event::LocalEvent(LocalEvent::TimeoutCheckElder) => {
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(&vote),
+            WaitedEvent::Rpc(rpc) => self.try_rpc(rpc),
+            WaitedEvent::LocalEvent(LocalEvent::TimeoutCheckElder) => {
                 Some(self.vote_parsec_check_elder())
             }
             _ => None,
@@ -547,9 +547,9 @@ impl ProcessElderChange {
             .as_process_elder_change()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::ParsecConsensus(vote) => self.try_consensus(&vote),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(&vote),
             _ => None,
         }
         .map(|state| state.0)
@@ -611,10 +611,10 @@ impl ProcessElderChange {
 pub struct CheckOnlineOffline(pub MemberState);
 
 impl CheckOnlineOffline {
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::ParsecConsensus(vote) => self.try_consensus(&vote),
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(&vote),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
             // Delegate to other event loops
             _ => None,
         }

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -401,14 +401,15 @@ impl StartResourceProof {
 
     fn check_request_resource_proof(&self) -> Self {
         if self.has_candidate() {
-            self.send_resource_proof_rpc()
+            self.send_resource_proof_rpc_and_schedule_proof_timeout()
         } else {
             self.finish_resource_proof()
         }
     }
 
-    fn send_resource_proof_rpc(&self) -> Self {
+    fn send_resource_proof_rpc_and_schedule_proof_timeout(&self) -> Self {
         self.0.action.send_candidate_proof_request(self.candidate());
+        self.0.action.schedule_event(LocalEvent::TimeoutAccept);
         self.clone()
     }
 

--- a/src/flows_node.rs
+++ b/src/flows_node.rs
@@ -9,7 +9,7 @@
 use crate::{
     state::*,
     utilities::{
-        Event, GenesisPfxInfo, LocalEvent, Name, ProofRequest, ProofSource, Rpc, SectionInfo,
+        GenesisPfxInfo, LocalEvent, Name, ProofRequest, ProofSource, Rpc, SectionInfo, WaitedEvent,
     },
 };
 use unwrap::unwrap;
@@ -25,10 +25,10 @@ impl JoiningRelocateCandidate {
             .start_refused_timeout()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<JoiningState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<JoiningState> {
         match event {
-            Event::Rpc(rpc) => self.try_rpc(rpc),
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::Rpc(rpc) => self.try_rpc(rpc),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
             _ => None,
         }
         .or_else(|| Some(self.discard()))

--- a/src/flows_src.rs
+++ b/src/flows_src.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     state::{MemberState, StartRelocateSrcState},
-    utilities::{Candidate, Event, LocalEvent, ParsecVote, RelocatedInfo, Rpc},
+    utilities::{Candidate, LocalEvent, ParsecVote, RelocatedInfo, Rpc, WaitedEvent},
 };
 use unwrap::unwrap;
 
@@ -22,12 +22,12 @@ impl TopLevelSrc {
         self.start_work_unit_timeout()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
-            Event::ParsecConsensus(vote) => self.try_consensus(vote),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(vote),
 
-            Event::Rpc(_) => None,
+            WaitedEvent::Rpc(_) => None,
         }
         .map(|state| state.0)
     }
@@ -100,11 +100,11 @@ impl StartRelocateSrc {
         self.start_check_relocate_timeout()
     }
 
-    pub fn try_next(&self, event: Event) -> Option<MemberState> {
+    pub fn try_next(&self, event: WaitedEvent) -> Option<MemberState> {
         match event {
-            Event::LocalEvent(local_event) => self.try_local_event(local_event),
-            Event::Rpc(rpc) => self.try_rpc(rpc),
-            Event::ParsecConsensus(vote) => self.try_consensus(vote),
+            WaitedEvent::LocalEvent(local_event) => self.try_local_event(local_event),
+            WaitedEvent::Rpc(rpc) => self.try_rpc(rpc),
+            WaitedEvent::ParsecConsensus(vote) => self.try_consensus(vote),
         }
         .map(|state| state.0)
     }

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -10,9 +10,9 @@ use crate::{
     actions::*,
     state::*,
     utilities::{
-        Age, Attributes, Candidate, CandidateInfo, Event, GenesisPfxInfo, LocalEvent, MergeInfo,
-        Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource,
-        RelocatedInfo, Rpc, Section, SectionInfo, State, TestEvent,
+        ActionTriggered, Age, Attributes, Candidate, CandidateInfo, Event, GenesisPfxInfo,
+        LocalEvent, MergeInfo, Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest,
+        ProofSource, RelocatedInfo, Rpc, Section, SectionInfo, State, TestEvent,
     },
 };
 use lazy_static::lazy_static;
@@ -382,7 +382,7 @@ mod dst_tests {
             }
             .to_event()],
             &AssertState {
-                action_our_events: vec![LocalEvent::NotYetImplementedEvent.to_event()],
+                action_our_events: vec![ActionTriggered::NotYetImplementedErrorTriggered.to_event()],
                 ..AssertState::default()
             },
         );
@@ -529,7 +529,7 @@ mod dst_tests {
                 action_our_events: vec![
                     NodeChange::Remove(TARGET_INTERVAL_1).to_event(),
                     LocalEvent::CheckRelocatedNodeConnectionTimeout.to_event(),
-                    LocalEvent::NotYetImplementedEvent.to_event(),
+                    ActionTriggered::NotYetImplementedErrorTriggered.to_event(),
                 ],
                 ..AssertState::default()
             },
@@ -941,9 +941,9 @@ mod dst_tests {
             ],
             &AssertState {
                 action_our_events: vec![
-                    LocalEvent::UnexpectedEventIgnored.to_event(),
-                    LocalEvent::UnexpectedEventIgnored.to_event(),
-                    LocalEvent::UnexpectedEventIgnored.to_event(),
+                    ActionTriggered::UnexpectedEventErrorTriggered.to_event(),
+                    ActionTriggered::UnexpectedEventErrorTriggered.to_event(),
+                    ActionTriggered::UnexpectedEventErrorTriggered.to_event(),
                 ],
                 ..AssertState::default()
             },
@@ -1251,6 +1251,7 @@ mod src_tests {
             ],
             &AssertState {
                 action_our_events: vec![
+                    ActionTriggered::WorkUnitIncremented.to_event(),
                     NodeChange::State(YOUNG_ADULT_205, State::RelocatingAgeIncrease).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_205).to_event(),
                 ],
@@ -1345,6 +1346,7 @@ mod src_tests {
             ],
             &AssertState {
                 action_our_events: vec![
+                    ActionTriggered::WorkUnitIncremented.to_event(),
                     NodeChange::State(YOUNG_ADULT_205, State::RelocatingAgeIncrease).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_205).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_1_OLD).to_event(),
@@ -1369,6 +1371,7 @@ mod src_tests {
             ],
             &AssertState {
                 action_our_events: vec![
+                    ActionTriggered::WorkUnitIncremented.to_event(),
                     NodeChange::State(NODE_ELDER_130, State::RelocatingAgeIncrease).to_event(),
                     ParsecVote::AddElderNode(YOUNG_ADULT_205).to_event(),
                     ParsecVote::RemoveElderNode(NODE_ELDER_130).to_event(),

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     utilities::{
         Age, Attributes, Candidate, CandidateInfo, ChangeElder, Event, GenesisPfxInfo, LocalEvent,
         MergeInfo, Name, Node, NodeChange, NodeState, ParsecVote, Proof, ProofRequest, ProofSource,
-        RelocatedInfo, Rpc, Section, SectionInfo, State,
+        RelocatedInfo, Rpc, Section, SectionInfo, State, TestEvent,
     },
 };
 use lazy_static::lazy_static;
@@ -440,17 +440,12 @@ mod dst_tests {
 
     #[test]
     fn parsec_expect_candidate_then_parsec_candidate_info_with_shorter_section_exists() {
-        let initial_state = MemberState {
-            action: Action::new(
-                INNER_ACTION_OLD_ELDERS
-                    .clone()
-                    .with_shortest_prefix(Some(OTHER_SECTION_1)),
-            ),
-            ..MemberState::default()
-        };
         let initial_state = arrange_initial_state(
-            &initial_state,
-            &[ParsecVote::ExpectCandidate(CANDIDATE_1_OLD).to_event()],
+            &initial_state_old_elders(),
+            &[
+                TestEvent::SetShortestPrefix(Some(OTHER_SECTION_1)).to_event(),
+                ParsecVote::ExpectCandidate(CANDIDATE_1_OLD).to_event(),
+            ],
         );
 
         run_test(
@@ -866,12 +861,14 @@ mod dst_tests {
     #[test]
     fn parsec_merge_needed() {
         let initial_state = initial_state_old_elders();
-        initial_state.action.set_merge_needed(true);
 
         run_test(
             "Merge needed",
             &initial_state,
-            &[ParsecVote::CheckElder.to_event()],
+            &[
+                TestEvent::SetMergeNeeded(true).to_event(),
+                ParsecVote::CheckElder.to_event(),
+            ],
             &AssertState {
                 action_our_rpcs: vec![Rpc::Merge],
                 ..AssertState::default()

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -1241,19 +1241,11 @@ mod src_tests {
 
     #[test]
     fn start_relocation() {
-        let initial_state = MemberState {
-            action: Action::new(
-                INNER_ACTION_OLD_ELDERS
-                    .clone()
-                    .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-            ),
-            ..MemberState::default()
-        };
-
         run_test(
             "Trigger events to relocate node",
-            &initial_state,
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1270,15 +1262,9 @@ mod src_tests {
     #[test]
     fn parsec_check_relocate_trigger_again_no_retry() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1298,15 +1284,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_again_until_retry() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
@@ -1331,7 +1311,6 @@ mod src_tests {
             action: Action::new(
                 INNER_ACTION_OLD_ELDERS
                     .clone()
-                    .with_enough_work_to_relocate(&[YOUNG_ADULT_205])
                     .extend_current_nodes_with(
                         &NodeState {
                             state: State::RelocatingHop,
@@ -1357,6 +1336,7 @@ mod src_tests {
             description,
             &initial_state,
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
@@ -1378,19 +1358,11 @@ mod src_tests {
 
     #[test]
     fn parsec_relocate_trigger_elder_change() {
-        let initial_state = MemberState {
-            action: Action::new(
-                INNER_ACTION_OLD_ELDERS
-                    .clone()
-                    .with_enough_work_to_relocate(&[NODE_ELDER_130]),
-            ),
-            ..MemberState::default()
-        };
-
         run_test(
             "Get Parsec ExpectCandidate then Online (Elder Change)",
-            &initial_state,
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(NODE_ELDER_130).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
                 ParsecVote::CheckElder.to_event(),
@@ -1410,15 +1382,9 @@ mod src_tests {
     #[test]
     fn parsec_relocate_trigger_elder_change_complete() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[NODE_ELDER_130]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(NODE_ELDER_130).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckElder.to_event(),
             ],
@@ -1449,15 +1415,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_refuse_candidate_rpc() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1477,15 +1437,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_relocate_response_rpc() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1512,15 +1466,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_accept() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1562,15 +1510,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_refuse() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
             ],
@@ -1587,15 +1529,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_refuse_trigger_again() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[YOUNG_ADULT_205]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(YOUNG_ADULT_205).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckRelocate.to_event(),
                 ParsecVote::RefuseCandidate(CANDIDATE_205).to_event(),
@@ -1616,15 +1552,9 @@ mod src_tests {
     #[test]
     fn parsec_relocation_trigger_elder_change_refuse_trigger_again() {
         let initial_state = arrange_initial_state(
-            &MemberState {
-                action: Action::new(
-                    INNER_ACTION_OLD_ELDERS
-                        .clone()
-                        .with_enough_work_to_relocate(&[NODE_ELDER_130]),
-                ),
-                ..MemberState::default()
-            },
+            &initial_state_old_elders(),
             &[
+                TestEvent::SetWorkUnitEnoughToRelocate(NODE_ELDER_130).to_event(),
                 ParsecVote::WorkUnitIncrement.to_event(),
                 ParsecVote::CheckElder.to_event(),
                 ParsecVote::RemoveElderNode(NODE_ELDER_130).to_event(),

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -139,7 +139,6 @@ lazy_static! {
 struct AssertState {
     action_our_events: Vec<Event>,
     action_our_section: SectionInfo,
-    action_merge_infos: Option<MergeInfo>,
 }
 
 fn process_events(mut state: MemberState, events: &[Event]) -> MemberState {
@@ -170,7 +169,6 @@ fn run_test(
         AssertState {
             action_our_events: action.our_events,
             action_our_section: action.our_section,
-            action_merge_infos: action.merge_infos,
         },
         final_state.failure,
     );
@@ -810,7 +808,7 @@ mod dst_tests {
             &initial_state_old_elders(),
             &[ParsecVote::NeighbourMerge(MergeInfo).to_event()],
             &AssertState {
-                action_merge_infos: Some(MergeInfo),
+                action_our_events: vec![ActionTriggered::MergeInfoStored(MergeInfo).to_event()],
                 ..AssertState::default()
             },
         );
@@ -828,7 +826,6 @@ mod dst_tests {
             &initial_state,
             &[ParsecVote::CheckElder.to_event()],
             &AssertState {
-                action_merge_infos: Some(MergeInfo),
                 action_our_events: vec![Rpc::Merge.to_event()],
                 ..AssertState::default()
             },

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -165,7 +165,6 @@ struct AssertState {
     action_our_events: Vec<LocalEvent>,
     action_our_section: SectionInfo,
     action_merge_infos: Option<MergeInfo>,
-    check_and_process_elder_change_routine: CheckAndProcessElderChangeState,
 }
 
 fn process_events(mut state: MemberState, events: &[Event]) -> MemberState {
@@ -200,8 +199,6 @@ fn run_test(
             action_our_events: action.our_events,
             action_our_section: action.our_section,
             action_merge_infos: action.merge_infos,
-            check_and_process_elder_change_routine: final_state
-                .check_and_process_elder_change_routine,
         },
         final_state.failure,
     );
@@ -842,9 +839,6 @@ mod dst_tests {
             &[ParsecVote::NeighbourMerge(MergeInfo).to_event()],
             &AssertState {
                 action_merge_infos: Some(MergeInfo),
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    ..Default::default()
-                },
                 ..AssertState::default()
             },
         );
@@ -864,9 +858,6 @@ mod dst_tests {
             &AssertState {
                 action_merge_infos: Some(MergeInfo),
                 action_our_rpcs: vec![Rpc::Merge],
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    ..Default::default()
-                },
                 ..AssertState::default()
             },
         );
@@ -940,13 +931,6 @@ mod dst_tests {
                 action_our_rpcs: vec![Rpc::NodeApproval(CANDIDATE_1, OUR_GENESIS_INFO)],
                 action_our_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
                 action_our_nodes: vec![SET_ONLINE_NODE_1],
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: ProcessElderChangeState {
-                        is_active: true,
-                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
-                        wait_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
-                    },
-                },
                 action_our_events: vec![LocalEvent::CheckResourceProofTimeout],
                 ..AssertState::default()
             },
@@ -983,13 +967,6 @@ mod dst_tests {
                     LocalEvent::UnexpectedEventIgnored,
                     LocalEvent::UnexpectedEventIgnored,
                 ],
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: ProcessElderChangeState {
-                        is_active: true,
-                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
-                        wait_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
-                    },
-                },
                 ..AssertState::default()
             },
         );
@@ -1012,19 +989,7 @@ mod dst_tests {
             "Get Parsec ExpectCandidate then Online (Elder Change) then RemoveElderNode",
             &initial_state,
             &[ParsecVote::RemoveElderNode(NODE_ELDER_109).to_event()],
-            &AssertState {
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: ProcessElderChangeState {
-                        is_active: true,
-                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
-                        wait_votes: vec![
-                            ParsecVote::AddElderNode(NODE_1),
-                            ParsecVote::NewSectionInfo(SECTION_INFO_1),
-                        ],
-                    },
-                },
-                ..AssertState::default()
-            },
+            &AssertState::default(),
         );
     }
 
@@ -1234,13 +1199,6 @@ mod dst_tests {
             &[ParsecVote::CheckElder.to_event()],
             &AssertState {
                 action_our_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: ProcessElderChangeState {
-                        is_active: true,
-                        change_elder: Some(SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone()),
-                        wait_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                    },
-                },
                 ..AssertState::default()
             },
         );
@@ -1454,13 +1412,6 @@ mod src_tests {
                     State::RelocatingAgeIncrease,
                 )],
                 action_our_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: ProcessElderChangeState {
-                        is_active: true,
-                        change_elder: Some(SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone()),
-                        wait_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                    },
-                },
                 ..AssertState::default()
             },
         );

--- a/src/scenario_tests.rs
+++ b/src/scenario_tests.rs
@@ -138,7 +138,6 @@ lazy_static! {
 #[derive(Debug, PartialEq, Default, Clone)]
 struct AssertState {
     action_our_events: Vec<Event>,
-    action_our_section: SectionInfo,
 }
 
 fn process_events(mut state: MemberState, events: &[Event]) -> MemberState {
@@ -168,7 +167,6 @@ fn run_test(
     let final_state = (
         AssertState {
             action_our_events: action.our_events,
-            action_our_section: action.our_section,
         },
         final_state.failure,
     );
@@ -221,7 +219,6 @@ mod dst_tests {
             &[Rpc::ExpectCandidate(CANDIDATE_1_OLD).to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::ExpectCandidate(CANDIDATE_1_OLD).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -248,7 +245,6 @@ mod dst_tests {
                     Rpc::RelocateResponse(CANDIDATE_RELOCATED_INFO_1).to_event(),
                     LocalEvent::CheckResourceProofTimeout.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -268,7 +264,6 @@ mod dst_tests {
                 action_our_events: vec![
                     Rpc::RelocateResponse(CANDIDATE_RELOCATED_INFO_1).to_event()
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -294,7 +289,6 @@ mod dst_tests {
                     connection_info: OUR_NAME.0,
                 }
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -320,7 +314,6 @@ mod dst_tests {
                     connection_info: OUR_NAME.0,
                 }
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -347,7 +340,6 @@ mod dst_tests {
             .to_event()],
             &AssertState {
                 action_our_events: vec![CANDIDATE_INFO_VALID_PARSEC_VOTE_1.to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -381,7 +373,6 @@ mod dst_tests {
             .to_event()],
             &AssertState {
                 action_our_events: vec![ActionTriggered::NotYetImplementedErrorTriggered.to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -407,7 +398,6 @@ mod dst_tests {
                     Rpc::NodeConnected(CANDIDATE_1, OUR_GENESIS_INFO).to_event(),
                     Rpc::RefuseCandidate(CANDIDATE_1_OLD).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -438,7 +428,6 @@ mod dst_tests {
                     Rpc::RefuseCandidate(CANDIDATE_1_OLD).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_1).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -469,7 +458,6 @@ mod dst_tests {
             &[LocalEvent::CheckRelocatedNodeConnectionTimeout.to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::CheckRelocatedNodeConnection.to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -496,7 +484,6 @@ mod dst_tests {
                     NodeChange::Remove(TARGET_INTERVAL_1).to_event(),
                     LocalEvent::CheckRelocatedNodeConnectionTimeout.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -529,7 +516,6 @@ mod dst_tests {
                     LocalEvent::CheckRelocatedNodeConnectionTimeout.to_event(),
                     ActionTriggered::NotYetImplementedErrorTriggered.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -575,7 +561,6 @@ mod dst_tests {
             &[LocalEvent::TimeoutAccept.to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::PurgeCandidate(CANDIDATE_1).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -625,7 +610,6 @@ mod dst_tests {
                     proof: OUR_PROOF_REQUEST,
                 }
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -656,7 +640,6 @@ mod dst_tests {
                     source: OUR_NAME,
                 }
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -683,7 +666,6 @@ mod dst_tests {
             .to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::Online(CANDIDATE_1).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -796,7 +778,6 @@ mod dst_tests {
             &[Rpc::Merge.to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::NeighbourMerge(MergeInfo).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -809,7 +790,6 @@ mod dst_tests {
             &[ParsecVote::NeighbourMerge(MergeInfo).to_event()],
             &AssertState {
                 action_our_events: vec![ActionTriggered::MergeInfoStored(MergeInfo).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -827,7 +807,6 @@ mod dst_tests {
             &[ParsecVote::CheckElder.to_event()],
             &AssertState {
                 action_our_events: vec![Rpc::Merge.to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -845,7 +824,6 @@ mod dst_tests {
             ],
             &AssertState {
                 action_our_events: vec![Rpc::Merge.to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -875,7 +853,6 @@ mod dst_tests {
                     LocalEvent::CheckResourceProofTimeout.to_event(),
                     LocalEvent::TimeoutCheckElder.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -907,7 +884,6 @@ mod dst_tests {
                     ParsecVote::RemoveElderNode(NODE_ELDER_109).to_event(),
                     ParsecVote::NewSectionInfo(SECTION_INFO_1).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -942,7 +918,6 @@ mod dst_tests {
                     ActionTriggered::UnexpectedEventErrorTriggered.to_event(),
                     ActionTriggered::UnexpectedEventErrorTriggered.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -991,13 +966,12 @@ mod dst_tests {
                 ParsecVote::NewSectionInfo(SECTION_INFO_1).to_event(),
             ],
             &AssertState {
-                action_our_section: SECTION_INFO_1,
                 action_our_events: vec![
                     NodeChange::Elder(NODE_1, true).to_event(),
                     NodeChange::Elder(NODE_ELDER_109, false).to_event(),
+                    ActionTriggered::OurSectionChanged(SECTION_INFO_1).to_event(),
                     LocalEvent::TimeoutCheckElder.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1027,7 +1001,6 @@ mod dst_tests {
                 ParsecVote::CheckResourceProof.to_event(),
             ],
             &&AssertState {
-                action_our_section: SECTION_INFO_1,
                 action_our_events: vec![
                     NodeChange::AddWithState(
                         Node(Attributes {
@@ -1051,7 +1024,6 @@ mod dst_tests {
                     .to_event(),
                     LocalEvent::CheckResourceProofTimeout.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1076,7 +1048,6 @@ mod dst_tests {
                     REMOVE_NODE_1.to_event(),
                     LocalEvent::CheckResourceProofTimeout.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1098,7 +1069,6 @@ mod dst_tests {
             &[ParsecVote::ExpectCandidate(CANDIDATE_2_OLD).to_event()],
             &AssertState {
                 action_our_events: vec![Rpc::RefuseCandidate(CANDIDATE_2_OLD).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1150,7 +1120,6 @@ mod dst_tests {
                     ParsecVote::Offline(NODE_ELDER_130).to_event(),
                     ParsecVote::BackOnline(NODE_ELDER_131).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1165,7 +1134,6 @@ mod dst_tests {
                 action_our_events: vec![
                     NodeChange::State(NODE_ELDER_130, State::Offline).to_event()
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1186,7 +1154,6 @@ mod dst_tests {
                     ParsecVote::RemoveElderNode(NODE_ELDER_130).to_event(),
                     ParsecVote::NewSectionInfo(SECTION_INFO_1).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1207,7 +1174,6 @@ mod dst_tests {
                     State::RelocatingBackOnline,
                 )
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1231,7 +1197,6 @@ mod src_tests {
                     ParsecVote::WorkUnitIncrement.to_event(),
                     LocalEvent::TimeoutWorkUnit.to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1252,7 +1217,6 @@ mod src_tests {
                     NodeChange::State(YOUNG_ADULT_205, State::RelocatingAgeIncrease).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_205).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1298,7 +1262,6 @@ mod src_tests {
             &[ParsecVote::CheckRelocate.to_event()],
             &AssertState {
                 action_our_events: vec![Rpc::ExpectCandidate(CANDIDATE_205).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1350,7 +1313,6 @@ mod src_tests {
                     Rpc::ExpectCandidate(CANDIDATE_2).to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_205).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1374,7 +1336,6 @@ mod src_tests {
                     ParsecVote::RemoveElderNode(NODE_ELDER_130).to_event(),
                     ParsecVote::NewSectionInfo(SECTION_INFO_1).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1400,14 +1361,13 @@ mod src_tests {
                 ParsecVote::CheckRelocate.to_event(),
             ],
             &AssertState {
-                action_our_section: SECTION_INFO_1,
                 action_our_events: vec![
                     NodeChange::Elder(YOUNG_ADULT_205, true).to_event(),
                     NodeChange::Elder(NODE_ELDER_130, false).to_event(),
+                    ActionTriggered::OurSectionChanged(SECTION_INFO_1).to_event(),
                     LocalEvent::TimeoutCheckElder.to_event(),
                     Rpc::ExpectCandidate(CANDIDATE_130).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1429,7 +1389,6 @@ mod src_tests {
             &[Rpc::RefuseCandidate(CANDIDATE_205).to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::RefuseCandidate(CANDIDATE_205).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1458,7 +1417,6 @@ mod src_tests {
                     DST_SECTION_INFO_200,
                 ))
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1502,7 +1460,6 @@ mod src_tests {
                         .to_event(),
                     NodeChange::Remove(YOUNG_ADULT_205.name()).to_event(),
                 ],
-                ..AssertState::default()
             },
         );
     }
@@ -1544,7 +1501,6 @@ mod src_tests {
             &[ParsecVote::CheckRelocate.to_event()],
             &AssertState {
                 action_our_events: vec![Rpc::ExpectCandidate(CANDIDATE_205).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1570,9 +1526,7 @@ mod src_tests {
             &initial_state,
             &[ParsecVote::CheckRelocate.to_event()],
             &AssertState {
-                action_our_section: SECTION_INFO_1,
                 action_our_events: vec![Rpc::ExpectCandidate(CANDIDATE_130).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1585,7 +1539,6 @@ mod src_tests {
             &[Rpc::RefuseCandidate(CANDIDATE_205).to_event()],
             &AssertState {
                 action_our_events: vec![ParsecVote::RefuseCandidate(CANDIDATE_205).to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1605,7 +1558,6 @@ mod src_tests {
                     DST_SECTION_INFO_200,
                 ))
                 .to_event()],
-                ..AssertState::default()
             },
         );
     }
@@ -1619,7 +1571,6 @@ mod node_tests {
     #[derive(Debug, PartialEq, Default, Clone)]
     struct AssertJoiningState {
         action_our_events: Vec<Event>,
-        action_our_section: SectionInfo,
         join_routine: JoiningRelocateCandidateState,
     }
 
@@ -1635,7 +1586,6 @@ mod node_tests {
         let final_state = (
             AssertJoiningState {
                 action_our_events: action.our_events,
-                action_our_section: action.our_section,
                 join_routine: final_state.join_routine,
             },
             final_state.failure,
@@ -1714,7 +1664,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }
@@ -1768,7 +1717,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }
@@ -1816,7 +1764,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }
@@ -1860,7 +1807,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }
@@ -1909,7 +1855,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }
@@ -1968,7 +1913,6 @@ mod node_tests {
                     ],
                     ..JoiningRelocateCandidateState::default()
                 },
-                ..AssertJoiningState::default()
             },
         );
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@
 
 use crate::{actions::*, flows_dst::*, flows_node::*, flows_src::*, utilities::*};
 use std::collections::{BTreeMap, BTreeSet};
+use unwrap::unwrap;
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct ProcessElderChangeState {
@@ -57,6 +58,13 @@ pub struct MemberState {
 
 impl MemberState {
     pub fn try_next(&self, event: Event) -> Option<Self> {
+        if let Some(test_event) = event.to_test_event() {
+            self.action.process_test_events(test_event);
+            return Some(self.clone());
+        }
+
+        let event = unwrap!(event.to_waited_event());
+
         if let Some(next) = self.as_check_and_process_elder_change().try_next(event) {
             return Some(next);
         }
@@ -96,7 +104,7 @@ impl MemberState {
         }
 
         match event {
-            Event::Rpc(Rpc::ConnectionInfoResponse { .. }) => {
+            WaitedEvent::Rpc(Rpc::ConnectionInfoResponse { .. }) => {
                 self.action
                     .schedule_event(LocalEvent::NotYetImplementedEvent);
                 Some(self.clone())
@@ -104,9 +112,9 @@ impl MemberState {
             // These should only happen if a routine started them, so it should have
             // handled them too, but other routine are not there yet and we want to test
             // these do not fail.
-            Event::ParsecConsensus(ParsecVote::RemoveElderNode(_))
-            | Event::ParsecConsensus(ParsecVote::AddElderNode(_))
-            | Event::ParsecConsensus(ParsecVote::NewSectionInfo(_)) => {
+            WaitedEvent::ParsecConsensus(ParsecVote::RemoveElderNode(_))
+            | WaitedEvent::ParsecConsensus(ParsecVote::AddElderNode(_))
+            | WaitedEvent::ParsecConsensus(ParsecVote::NewSectionInfo(_)) => {
                 self.action
                     .schedule_event(LocalEvent::UnexpectedEventIgnored);
                 Some(self.clone())
@@ -178,6 +186,13 @@ impl JoiningState {
     }
 
     pub fn try_next(&self, event: Event) -> Option<Self> {
+        if let Some(test_event) = event.to_test_event() {
+            self.action.process_test_events(test_event);
+            return Some(self.clone());
+        }
+
+        let event = unwrap!(event.to_waited_event());
+
         if let Some(next) = self.as_joining_relocate_candidate().try_next(event) {
             return Some(next);
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,7 +106,7 @@ impl MemberState {
         match event {
             WaitedEvent::Rpc(Rpc::ConnectionInfoResponse { .. }) => {
                 self.action
-                    .schedule_event(LocalEvent::NotYetImplementedEvent);
+                    .action_triggered(ActionTriggered::NotYetImplementedErrorTriggered);
                 Some(self.clone())
             }
             // These should only happen if a routine started them, so it should have
@@ -116,7 +116,7 @@ impl MemberState {
             | WaitedEvent::ParsecConsensus(ParsecVote::AddElderNode(_))
             | WaitedEvent::ParsecConsensus(ParsecVote::NewSectionInfo(_)) => {
                 self.action
-                    .schedule_event(LocalEvent::UnexpectedEventIgnored);
+                    .action_triggered(ActionTriggered::UnexpectedEventErrorTriggered);
                 Some(self.clone())
             }
 

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -415,6 +415,7 @@ impl TestEvent {
 pub enum ActionTriggered {
     WorkUnitIncremented,
     MergeInfoStored(MergeInfo),
+    OurSectionChanged(SectionInfo),
 
     // WaitedEvent that should be handled by a flow but are not.
     NotYetImplementedErrorTriggered,

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -56,6 +56,12 @@ pub enum NodeChange {
     Elder(Node, bool),
 }
 
+impl NodeChange {
+    pub fn to_event(self) -> Event {
+        Event::NodeChange(self)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct RelocatedInfo {
     pub candidate: Candidate,
@@ -218,6 +224,7 @@ pub enum Event {
     ParsecConsensus(ParsecVote),
     LocalEvent(LocalEvent),
     TestEvent(TestEvent),
+    NodeChange(NodeChange),
 }
 
 impl Event {
@@ -226,7 +233,7 @@ impl Event {
             Event::Rpc(rpc) => Some(WaitedEvent::Rpc(rpc)),
             Event::ParsecConsensus(parsec_vote) => Some(WaitedEvent::ParsecConsensus(parsec_vote)),
             Event::LocalEvent(local_event) => Some(WaitedEvent::LocalEvent(local_event)),
-            Event::TestEvent(_test_event) => None,
+            Event::TestEvent(_) | Event::NodeChange(_) => None,
         }
     }
 

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -206,10 +206,36 @@ pub struct CandidateInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WaitedEvent {
+    Rpc(Rpc),
+    ParsecConsensus(ParsecVote),
+    LocalEvent(LocalEvent),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {
     Rpc(Rpc),
     ParsecConsensus(ParsecVote),
     LocalEvent(LocalEvent),
+    TestEvent(TestEvent),
+}
+
+impl Event {
+    pub fn to_waited_event(&self) -> Option<WaitedEvent> {
+        match *self {
+            Event::Rpc(rpc) => Some(WaitedEvent::Rpc(rpc)),
+            Event::ParsecConsensus(parsec_vote) => Some(WaitedEvent::ParsecConsensus(parsec_vote)),
+            Event::LocalEvent(local_event) => Some(WaitedEvent::LocalEvent(local_event)),
+            Event::TestEvent(_test_event) => None,
+        }
+    }
+
+    pub fn to_test_event(&self) -> Option<TestEvent> {
+        match *self {
+            Event::TestEvent(test_event) => Some(test_event),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -356,7 +382,7 @@ pub enum LocalEvent {
     NodeDetectedOffline(Node),
     NodeDetectedBackOnline(Node),
 
-    // Event that should be handled by a flow but are not.
+    // WaitedEvent that should be handled by a flow but are not.
     NotYetImplementedEvent,
     // Unexpected event ignored:
     UnexpectedEventIgnored,
@@ -365,5 +391,17 @@ pub enum LocalEvent {
 impl LocalEvent {
     pub fn to_event(&self) -> Event {
         Event::LocalEvent(*self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TestEvent {
+    SetMergeNeeded(bool),
+    SetShortestPrefix(Option<Section>),
+}
+
+impl TestEvent {
+    pub fn to_event(self) -> Event {
+        Event::TestEvent(self)
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -224,7 +224,9 @@ pub enum Event {
     ParsecConsensus(ParsecVote),
     LocalEvent(LocalEvent),
     TestEvent(TestEvent),
+
     NodeChange(NodeChange),
+    ActionTriggered(ActionTriggered),
 }
 
 impl Event {
@@ -233,7 +235,7 @@ impl Event {
             Event::Rpc(rpc) => Some(WaitedEvent::Rpc(rpc)),
             Event::ParsecConsensus(parsec_vote) => Some(WaitedEvent::ParsecConsensus(parsec_vote)),
             Event::LocalEvent(local_event) => Some(WaitedEvent::LocalEvent(local_event)),
-            Event::TestEvent(_) | Event::NodeChange(_) => None,
+            Event::TestEvent(_) | Event::NodeChange(_) | Event::ActionTriggered(_) => None,
         }
     }
 
@@ -388,11 +390,6 @@ pub enum LocalEvent {
     ComputeResourceProofForElder(Name, ProofSource),
     NodeDetectedOffline(Node),
     NodeDetectedBackOnline(Node),
-
-    // WaitedEvent that should be handled by a flow but are not.
-    NotYetImplementedEvent,
-    // Unexpected event ignored:
-    UnexpectedEventIgnored,
 }
 
 impl LocalEvent {
@@ -411,5 +408,21 @@ pub enum TestEvent {
 impl TestEvent {
     pub fn to_event(self) -> Event {
         Event::TestEvent(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ActionTriggered {
+    WorkUnitIncremented,
+
+    // WaitedEvent that should be handled by a flow but are not.
+    NotYetImplementedErrorTriggered,
+    // Unexpected event ignored.
+    UnexpectedEventErrorTriggered,
+}
+
+impl ActionTriggered {
+    pub fn to_event(self) -> Event {
+        Event::ActionTriggered(self)
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -405,6 +405,7 @@ impl LocalEvent {
 pub enum TestEvent {
     SetMergeNeeded(bool),
     SetShortestPrefix(Option<Section>),
+    SetWorkUnitEnoughToRelocate(Node),
 }
 
 impl TestEvent {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -414,6 +414,7 @@ impl TestEvent {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ActionTriggered {
     WorkUnitIncremented,
+    MergeInfoStored(MergeInfo),
 
     // WaitedEvent that should be handled by a flow but are not.
     NotYetImplementedErrorTriggered,

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -211,6 +211,8 @@ pub struct CandidateInfo {
     pub valid: bool,
 }
 
+// Event passed to get out of "Wait for" state in flow diagram:
+// Pass to try_next to the implementations.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WaitedEvent {
     Rpc(Rpc),
@@ -218,6 +220,7 @@ pub enum WaitedEvent {
     LocalEvent(LocalEvent),
 }
 
+// Event allowing to drive the tests and collect output, a superset of WaitedEvent.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {
     Rpc(Rpc),


### PR DESCRIPTION
Avoid using final state validation: validate state changes.
Combine all state changes output into a common vector to simplify things and clarify order of events.
Replace Event with WaitedEvent (events that flow/routine take as parameters).

introduce in its Place Event: contain more variant to specify other test inputs and outputs.
This allow specifying outside change like 'merge_needed' or if a section with shorter prefix is detected, or if work unit is reached to relocate, thus making all test setups more similar.
It also allow to specify more output like we incremented the work unit for our nodes, or we stored the merge info from a neighbor section.