### PR TITLE
fix/routing_model: update diagram and implementation of joining node

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,16 +121,63 @@
   This node is going to try to be accepted as candidate until it receives a Rpc::NodeConnected to complete this stage successfully.<br/>
   This node is going to perform the resource proof until it receives a Rpc::NodeApproval to complete this stage successfully.<br/>
   If the node is not accepted, after time out, it will try another section as a new node.
+  <button class="collapsible">TimeoutResendInfo</button>
+  <div class="content">
+      <p>Timeout triggered to resend messages that have been lost: Either Rpc::CandidateInfo or Rpc::ResourceProofResponse
+      </p>
+  </div>
+  <button class="collapsible">TimeoutConnectRefused</button>
+  <div class="content">
+      <p>Timeout to stop trying to connect if so much time has elapsed that we will not be able to succeed.
+      </p>
+  </div>
+  <button class="collapsible">TimeoutProofRefused</button>
+  <div class="content">
+      <p>Timeout to stop trying to resource proof if so much time has elapsed that we will not be able to succeed.
+      </p>
+  </div>
+  <button class="collapsible">get_next_resource_proof_part</button>
+  <div class="content">
+      <p>Return the next part of the resource proof for the given elder.<br/>
+      inputs:<br/>
+          - elder name<br/>
+      </p>
+  </div>
+  <button class="collapsible">get_resend_resource_proof_part</button>
+  <div class="content">
+      <p>Return the last part of the resource proof for the given elder that we sent.<br/>
+      inputs:<br/>
+          - elder name<br/>
+      </p>
+  </div>
+  <button class="collapsible">get_resource_proof_elders</button>
+  <div class="content">
+      <p>Return all the elders we are currently sending resource proofs to.
+      </p>
+  </div>
+  <button class="collapsible">NEED_RESEND_PROOFS</button>
+  <div class="content">
+      <p>Collection of elders we have not sent a ResourceProofResponse during the timeout.
+      </p>
+  </div>
+  <button class="collapsible">CONNECTED</button>
+  <div class="content">
+      <p>Indicate whether we successfully connected, and if so resend Rpc::ResourceProofResponse instead of Rpc::CandidateInfo.
+      </p>
+  </div>
+  <button class="collapsible">RELOCATED_INFO</button>
+  <div class="content">
+      <p>The RelocatedInfo given to the routine and used to send CandidateInfo
+      </p>
+  </div>
   </div>
   <div class="mermaid">
     graph TB
     JoiningRelocateCandidate -->  InitialSendConnectionInfoRequest
-    JoiningRelocateCandidate["JoiningRelocateCandidate<br/>(Take destination section nodes)"]
+    JoiningRelocateCandidate["JoiningRelocateCandidate<br/>(Take RelocatedInfo)"]
     style JoiningRelocateCandidate fill:#f9f,stroke:#333,stroke-width:4px
-    EndRoutine["End of JoiningRelocateCandidate<br/>"]
-    style EndRoutine fill:#f9f,stroke:#333,stroke-width:4px
 
-    InitialSendConnectionInfoRequest["send_rpc(Rpc::CandidateInfo) to target NaeManger<br/><br/>schedule(TimeoutResendInfo)<br/>schedule(TimeoutRefused)"]
+    InitialSendConnectionInfoRequest["RELOCATED_INFO = RelocatedInfo<br/>send_rpc(Rpc::CandidateInfo from RELOCATED_INFO)<br/>to target NaeManger<br/><br/>schedule(TimeoutResendInfo)<br/>schedule(TimeoutConnectRefused)"]
     InitialSendConnectionInfoRequest-->LoopStart
 
     LoopStart --> WaitFor
@@ -138,22 +185,35 @@
     LocalEvent((Local<br/>Event))
     WaitFor --> LocalEvent
 
-    LocalEvent -- ResourceProofForElderReady -->  SendFirstResourceProofPartForElder
-    SendFirstResourceProofPartForElder["send_rpc(<br/>Rpc::ResourceProofResponse)<br/>with first part for elder"]
-    SendFirstResourceProofPartForElder --> LoopEnd
+    LocalEvent -- ResourceProofForElderReady -->  SendNextResourceProofPartForElder
 
-    LocalEvent--"TimeoutResendInfo triggered<br/>CONNECTED==false"--> ResendCandidateInfo
-    ResendCandidateInfo["send_rpc(Rpc::CandidateInfo)<br/><br/>schedule(TimeoutResendInfo)"]
-    ResendCandidateInfo --> LoopEnd
+    LocalEvent--"TimeoutResendInfo triggered"--> CheckResendCandidateInfo
+    CheckResendCandidateInfo((Check))
 
-    LocalEvent--"TimeoutRefused<br/>triggered"--> EndRoutine
+    CheckResendCandidateInfo -- "Otherwise" --> ResendCandidateInfo
+    ResendCandidateInfo["send_rpc(<br/>Rpc::CandidateInfo from RELOCATED_INFO)<br/>to target NaeManger<br/><br/>schedule(<br/>TimeoutResendInfo)"]
+    ResendCandidateInfo --> ScheduleResendTimeoutInfo
+
+    CheckResendCandidateInfo -- "CONNECTED==true" --> ResendProofs
+    ResendProofs["for name in NEED_RESEND_PROOFS:<br/>send_rpc(<br/>Rpc::ResourceProofResponse{<br/>get_resend_resource_proof_part(<br/>name)})<br/><br/>NEED_RESEND_PROOFS=<br/>get_resource_proof_elders()"]
+    ResendProofs --> ScheduleResendTimeoutInfo
+
+    ScheduleResendTimeoutInfo["schedule(<br/>TimeoutResendInfo)"]
+    ScheduleResendTimeoutInfo --> LoopEnd
+
+    SendNextResourceProofPartForElder["NEED_RESEND_PROOFS.remove(<br/>elder name)<br/><br/>send_rpc(<br/>Rpc::ResourceProofResponse{<br/>get_next_resource_proof_part(<br/>elder name)})"]
+    SendNextResourceProofPartForElder --> LoopEnd
+
+    LocalEvent--"TimeoutConnectRefused<br/>or<br/>TimeoutProofRefused<br/>triggered"--> EndRoutine
+    EndRoutine["End of JoiningRelocateCandidate<br/>"]
+    style EndRoutine fill:#f9f,stroke:#333,stroke-width:4px
 
     Rpc((RPC))
     WaitFor --> Rpc
     Rpc -- Rpc::NodeApproval -->  EndRoutine
 
     Rpc -- Rpc::NodeConnected --> NodeConnected
-    NodeConnected["CONNECTED=true<br/><br/>kill_scheduled(TimeoutRefused)"]
+    NodeConnected["kill_scheduled(TimeoutConnectRefused)><br/>CONNECTED=true"]
     NodeConnected-->LoopEnd
 
     Rpc -- Rpc::ConnectionInfoRequest --> OnConnectionInfoRequest
@@ -161,11 +221,9 @@
     OnConnectionInfoRequest-->LoopEnd
 
     Rpc -- Rpc::ResourceProofReceipt -->  SendNextResourceProofPartForElder
-    SendNextResourceProofPartForElder["send_rpc(<br/>Rpc::ResourceProofResponse)<br/>part for elder"]
-    SendNextResourceProofPartForElder --> LoopEnd
 
     Rpc -- Rpc::ResourceProof -->  StartComputeResourceProofForElder
-    StartComputeResourceProofForElder["start_compute_resource_proof(source elder)<br/><br/>schedule(TimeoutRefused)"]
+    StartComputeResourceProofForElder["start_compute_resource_proof(source elder)<br/><br/>schedule(TimeoutProofRefused)"]
     StartComputeResourceProofForElder --> LoopEnd
 
     Rpc -- "Rpc::ExpectCandidate<br/>Rpc::ExpectCandidateRefuseResponse<br/>Rpc::ExpectCandidateAcceptResponse<br/>..." --> VoteParsecRPC
@@ -548,12 +606,12 @@
 
       RPC((RPC))
       WaitFor --RPC--> RPC
-      RPC -- Rpc::ResourceProofResponse<br/>from CANDIDATE<br/><br/>VOTED_ONLINE==no --> ProofResponse((Proof))
+      RPC -- Rpc::ResourceProofResponse<br/>from CANDIDATE --> ProofResponse((Proof))
       ProofResponse((Check))
       SendProofReceipt["send_rpc(<br/>Rpc::ResourceProofReceipt)<br/>for proof"]
-      ProofResponse -- Valid Part --> SendProofReceipt
+      ProofResponse -- "Valid Part or End<br/>otherwise" --> SendProofReceipt
       VoteParsecOnline["vote_for(<br/>Parsec::Online)<br/><br/>VOTED_ONLINE=yes"]
-      ProofResponse -- Valid End --> VoteParsecOnline
+      ProofResponse -- "Valid End<br/>and<br/>VOTED_ONLINE==no" --> VoteParsecOnline
 
 
       DiscardRPC[Discard RPC]
@@ -570,8 +628,8 @@
       VoteParsecCheckResourceProofTimeout --> LoopEnd
 
 
+      VoteParsecOnline --> SendProofReceipt
       SendProofReceipt-->LoopEnd
-      VoteParsecOnline --> LoopEnd
       VoteParsecPurgeCandidate --> LoopEnd
       LoopEnd --> LoopStart
 

--- a/src/flows_dst.rs
+++ b/src/flows_dst.rs
@@ -278,14 +278,11 @@ impl<'a> StartResourceProof<'a> {
         let from_candidate = self.has_candidate() && candidate == self.candidate();
 
         if from_candidate && !self.routine_state().voted_online && proof.is_valid() {
-            match proof {
-                Proof::ValidPart => self.send_resource_proof_receipt_rpc(),
-                Proof::ValidEnd => {
-                    self.set_voted_online(true);
-                    self.vote_parsec_online_candidate();
-                }
-                Proof::Invalid => panic!("Only valid proof"),
+            if proof == Proof::ValidEnd {
+                self.set_voted_online(true);
+                self.vote_parsec_online_candidate();
             }
+            self.send_resource_proof_receipt_rpc();
         } else {
             self.discard()
         }

--- a/src/flows_node.rs
+++ b/src/flows_node.rs
@@ -9,8 +9,7 @@
 use crate::{
     state::*,
     utilities::{
-        GenesisPfxInfo, LocalEvent, Name, ProofRequest, ProofSource, Rpc, SectionInfo, TryResult,
-        WaitedEvent,
+        GenesisPfxInfo, LocalEvent, Name, ProofRequest, RelocatedInfo, Rpc, TryResult, WaitedEvent,
     },
 };
 use unwrap::unwrap;
@@ -19,11 +18,12 @@ use unwrap::unwrap;
 pub struct JoiningRelocateCandidate<'a>(pub &'a mut JoiningState);
 
 impl<'a> JoiningRelocateCandidate<'a> {
-    pub fn start_event_loop(&mut self, new_section: SectionInfo) {
-        self.store_destination_members(new_section);
-        self.send_connection_info_requests();
+    pub fn start_event_loop(&mut self, relocated_info: RelocatedInfo) {
+        self.0.join_routine.relocated_info = Some(relocated_info);
+
+        self.send_candidate_info();
         self.start_resend_info_timeout();
-        self.start_refused_timeout();
+        self.start_refused_connect_timeout();
     }
 
     pub fn try_next(&mut self, event: WaitedEvent) -> TryResult {
@@ -40,15 +40,6 @@ impl<'a> JoiningRelocateCandidate<'a> {
     }
 
     fn try_rpc(&mut self, rpc: Rpc) -> TryResult {
-        if let Rpc::NodeApproval(candidate, info) = &rpc {
-            if self.0.action.is_our_name(Name(candidate.0.name)) {
-                self.exit(*info);
-                return TryResult::Handled;
-            } else {
-                return TryResult::Unhandled;
-            }
-        }
-
         if !rpc
             .destination()
             .map(|name| self.0.action.is_our_name(name))
@@ -58,12 +49,20 @@ impl<'a> JoiningRelocateCandidate<'a> {
         }
 
         match rpc {
-            Rpc::ConnectionInfoResponse {
+            Rpc::NodeConnected(_, _) => {
+                self.complete_connected();
+                TryResult::Handled
+            }
+            Rpc::NodeApproval(_, info) => {
+                self.exit(info);
+                TryResult::Handled
+            }
+            Rpc::ConnectionInfoRequest {
                 source,
                 connection_info,
                 ..
             } => {
-                self.connect_and_send_candidate_info(source, connection_info);
+                self.send_connection_info_response(source, connection_info);
                 TryResult::Handled
             }
             Rpc::ResourceProof { proof, source, .. } => {
@@ -80,99 +79,98 @@ impl<'a> JoiningRelocateCandidate<'a> {
 
     fn try_local_event(&mut self, local_event: LocalEvent) -> TryResult {
         match local_event {
-            LocalEvent::ComputeResourceProofForElder(source, proof) => {
-                self.send_first_proof_response(source, proof);
+            LocalEvent::ResourceProofForElderReady(source) => {
+                self.send_next_proof_response(source);
                 TryResult::Handled
             }
-            LocalEvent::JoiningTimeoutResendCandidateInfo => {
-                self.send_connection_info_requests();
-                self.start_resend_info_timeout();
+            LocalEvent::JoiningTimeoutResendInfo => {
+                self.check_connected_and_resend_info();
                 TryResult::Handled
             }
             _ => TryResult::Unhandled,
         }
     }
 
+    fn check_connected_and_resend_info(&mut self) {
+        if self.0.join_routine.connected {
+            self.resend_proofs();
+        } else {
+            self.send_candidate_info();
+        }
+        self.start_resend_info_timeout();
+    }
+
     fn exit(&mut self, info: GenesisPfxInfo) {
-        self.0.join_routine.has_resource_proofs.clear();
-        self.0.join_routine.routine_complete = Some(info);
+        self.0.join_routine.routine_complete_output = Some(info);
     }
 
     fn discard(&mut self) {}
 
-    fn store_destination_members(&mut self, section: SectionInfo) {
-        let members = self.0.action.get_section_members(section);
-        self.0.join_routine.has_resource_proofs = members
-            .iter()
-            .map(|node| (Name(node.0.name), (false, None)))
-            .collect();
-    }
-
-    fn send_connection_info_requests(&mut self) {
-        let has_resource_proofs = &self.0.join_routine.has_resource_proofs;
-        for (name, _) in has_resource_proofs.iter().filter(|(_, value)| !value.0) {
-            self.0.action.send_connection_info_request(*name);
-        }
-    }
-
-    fn send_first_proof_response(&mut self, source: Name, mut proof_source: ProofSource) {
-        let proof = self
-            .0
-            .join_routine
-            .has_resource_proofs
-            .get_mut(&source)
-            .unwrap();
-
-        let next_part = proof_source.next_part();
-        proof.1 = Some(proof_source);
-
-        self.0
-            .action
-            .send_resource_proof_response(source, next_part);
+    fn send_connection_info_response(&mut self, source: Name, _connect_info: i32) {
+        self.0.action.send_connection_info_response(source);
     }
 
     fn send_next_proof_response(&mut self, source: Name) {
-        let proof_source = &mut unwrap!(self
-            .0
-            .join_routine
-            .has_resource_proofs
-            .get_mut(&source)
-            .unwrap()
-            .1
-            .as_mut());
-
-        let next_part = proof_source.next_part();
-        self.0
-            .action
-            .send_resource_proof_response(source, next_part);
+        if let Some(next_part) = self.0.action.get_next_resource_proof_part(source) {
+            self.0
+                .action
+                .send_resource_proof_response(source, next_part);
+        }
     }
 
-    fn connect_and_send_candidate_info(&mut self, source: Name, _connect_info: i32) {
-        self.0.action.send_candidate_info(source);
+    fn resend_proof_response(&mut self, source: Name) {
+        if let Some(next_part) = self.0.action.get_resend_resource_proof_part(source) {
+            self.0
+                .action
+                .send_resource_proof_response(source, next_part);
+        }
+    }
+
+    fn send_candidate_info(&mut self) {
+        self.0
+            .action
+            .send_candidate_info(unwrap!(self.0.join_routine.relocated_info));
     }
 
     fn start_resend_info_timeout(&mut self) {
         self.0
             .action
-            .schedule_event(LocalEvent::JoiningTimeoutResendCandidateInfo);
+            .schedule_event(LocalEvent::JoiningTimeoutResendInfo);
     }
 
-    fn start_refused_timeout(&mut self) {
+    fn start_refused_connect_timeout(&mut self) {
         self.0
             .action
-            .schedule_event(LocalEvent::JoiningTimeoutRefused);
+            .schedule_event(LocalEvent::JoiningTimeoutConnectRefused);
+    }
+
+    fn complete_connected(&mut self) {
+        self.0.join_routine.connected = true;
+        self.0
+            .action
+            .kill_scheduled_event(LocalEvent::JoiningTimeoutConnectRefused);
     }
 
     fn start_compute_resource_proof(&mut self, source: Name, proof: ProofRequest) {
+        self.0
+            .action
+            .schedule_event(LocalEvent::JoiningTimeoutProofRefused);
         self.0.action.start_compute_resource_proof(source, proof);
-        let proof = self
-            .0
+    }
+
+    fn resend_proofs(&mut self) {
+        self.0
             .join_routine
-            .has_resource_proofs
-            .get_mut(&source)
-            .unwrap();
-        if !proof.0 {
-            *proof = (true, None);
-        }
+            .need_resend_proofs
+            .clone()
+            .iter()
+            .for_each(|name| self.resend_proof_response(*name));
+
+        self.0.join_routine.need_resend_proofs = self
+            .0
+            .action
+            .get_resource_proof_elders()
+            .into_iter()
+            .collect();
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -163,8 +163,11 @@ impl MemberState {
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct JoiningRelocateCandidateState {
-    pub has_resource_proofs: BTreeMap<Name, (bool, Option<ProofSource>)>,
-    pub routine_complete: Option<GenesisPfxInfo /*output*/>,
+    pub relocated_info: Option<RelocatedInfo>,
+    pub connected: bool,
+    pub need_resend_proofs: BTreeSet<Name>,
+
+    pub routine_complete_output: Option<GenesisPfxInfo /*output*/>,
 }
 
 // The very top level event loop deciding how the sub event loops are processed
@@ -176,9 +179,9 @@ pub struct JoiningState {
 }
 
 impl JoiningState {
-    pub fn start(&mut self, new_section: SectionInfo) {
+    pub fn start(&mut self, relocated_info: RelocatedInfo) {
         self.as_joining_relocate_candidate()
-            .start_event_loop(new_section)
+            .start_event_loop(relocated_info)
     }
 
     pub fn try_next(&mut self, event: Event) -> TryResult {


### PR DESCRIPTION
Rendered: https://raw.githack.com/maidsafe/routing_model/74ccfceab9b3d224538c584246d04e3611861655/index.html

Update to match StartRelocatedNodeConnection and StartResourceProof.
Fix StartResourceProof to send receipt so node does not resend last
part again.
Fix JoiningRelocateCandidate to resend proof if no receipt.

Clean up test:
- Schedule with ComputeResourceProofForElder, but received event is
  ResourceProofForElderReady to match diagram.
- Add Scheduled/Killed Action trigger to clean up test results.
- Remove join_routine from test cases like other flows.